### PR TITLE
Add mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Euan Harris <euan_harris@apple.com> <euanh@apple.com>


### PR DESCRIPTION
### Motivation

The contributors list is generated using `git shortlog`.   Git can use the `.mailmap` file to link commits from the same contributor using different email addresses.

### Modifications

Add .mailmap file with initial mappings.

### Result

Contributors using different email addresses will not be duplicated.

### Test Plan

Re-ran soundness script, no change in contributors file.