### PR TITLE
Package: Replace deprecated `swiftLanguageVersions` parameter

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -88,5 +88,5 @@ let package = Package(
             resources: [.process("Resources")]
         ),
     ],
-    swiftLanguageVersions: [.version("6")]
+    swiftLanguageModes: [.v6]
 )


### PR DESCRIPTION
### Motivation

The `swiftLanguageVersions` parameter is deprecated and has been replaced by `swiftLanguageModes`

### Modifications

Replace `swiftLanguageVersions` with `swiftLanguageModes`.

### Result

Swift Package Manager no longer prints a deprecation warning during the build.

### Test Plan

Built and tested the Vapor example project using the updated plugin.