### PR TITLE
Use v5 language mode for containertool

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,6 @@ jobs:
         uses: apple/swift-nio/.github/workflows/soundness.yml@main
         with:
             api_breakage_check_container_image: "swift:6.0-noble"
-            api_breakage_check_enabled: false
             docs_check_container_image: "swift:6.0-noble"
             license_header_check_project_name: "SwiftContainerPlugin"
             shell_check_container_image: "swift:6.0-noble"

--- a/.spi.yml
+++ b/.spi.yml
@@ -2,5 +2,5 @@ version: 1
 builder:
   configs:
   - documentation_targets:
-    - ContainerRegistry
+    - containertool
     - ContainerImageBuilderPlugin

--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,8 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Crypto", package: "swift-crypto", condition: .when(platforms: [.linux])),
                 .target(name: "ContainerRegistry"), .target(name: "VendorCNIOExtrasZlib"),
-            ]
+            ],
+            swiftSettings: [.swiftLanguageMode(.v5)]
         ),
         .target(
             // Vendored from https://github.com/apple/swift-nio-extras


### PR DESCRIPTION
### Motivation

The containertool target will not build with the `nightly` Linux image currently being used for some of the CI tests.   Falling back to Swift Language Mode v5 allows all tests to be enabled.

### Modifications

The containertool target is declared to use the v5 language mode.
The `api_breakage_check` test is enabled.

### Result

`containertool` will build using Linux images, and the breakage checks will run.

### Test Plan

Built locally and verified that the new tests pass using `act pull_request`.