### PR TITLE
ci: Enable Swift 6 Language Mode checks

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,3 +13,7 @@ jobs:
             docs_check_container_image: "swift:6.0-noble"
             license_header_check_project_name: "SwiftContainerPlugin"
             shell_check_container_image: "swift:6.0-noble"
+
+    swift-6-language-mode:
+        name: Swift 6 Language Mode
+        uses: apple/swift-nio/.github/workflows/swift_6_language_mode.yml@main

--- a/Vendor/github.com/apple/swift-package-manager/Sources/Basics/AuthorizationProvider.swift
+++ b/Vendor/github.com/apple/swift-package-manager/Sources/Basics/AuthorizationProvider.swift
@@ -78,7 +78,7 @@ public final class NetrcAuthorizationProvider: AuthorizationProvider {
 
     private static func load(_ path: URL) throws -> Netrc? {
         do {
-            let content = try? String(contentsOf: path)
+            let content = try? String(contentsOf: path, encoding: .utf8)
             return try NetrcParser.parse(content ?? "")
         } catch NetrcError.machineNotFound {
             // Thrown by parse() if .netrc is empty.


### PR DESCRIPTION
### Motivation

Much of the project passes the Swift 6 language mode checks, so we should run them on each pull request to prevent regressions.

### Modifications

Enable the Swift 6 language mode check job in the pull request workflow and fix the errors it finds.

### Result

The Swift 6 checks will pass.

### Test Plan

Ran the checks locally using `act pull_request`.