### PR TITLE
Examples: Update the Vapor example

### DIFF
--- a/Examples/HelloWorldVapor/Package.resolved
+++ b/Examples/HelloWorldVapor/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "03b643cf45dc733223c9d16fefb1e7c2761da86551d1a899f6872700e2c9673b",
+  "originHash" : "fa93d713c694f8fecb4633afc7d3d8dd9d29fa1946c8f99ad9ed42bbe578c36d",
   "pins" : [
     {
       "identity" : "async-http-client",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "11205411bb60612f0a1a04f733fa71b4fb864ab9",
-        "version" : "1.22.1"
+        "revision" : "64abc77edf1ef81e69bd90a2ac386de615c8e8ea",
+        "version" : "1.23.0"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "81bee98e706aee68d39ed5996db069ef2b313d62",
-        "version" : "3.7.1"
+        "revision" : "ffca28be3c9c6a86a579949d23f68818a4b9b5d8",
+        "version" : "3.8.0"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "1b33db2dea6a64d5b619b9e888175133c6d7f410",
-        "version" : "2.73.0"
+        "revision" : "665206000b8307cab5ac51203d29b0f232d7e31b",
+        "version" : "2.74.0"
       }
     },
     {

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -61,3 +61,14 @@ function from SwiftNIO Extras.
     * https://www.apache.org/licenses/LICENSE-2.0
   * HOMEPAGE:
     * https://github.com/swift-server/swift-nio-extras
+
+-------------------------------------------------------------------------------
+
+This product contains samples of how to use Swift Container Plugin with the
+following other projects:
+
+  * Vapor
+    * LICENSE (MIT License):
+      * https://mit-license.org
+    * HOMEPAGE:
+      * https://github.com/vapor/vapor


### PR DESCRIPTION
### Motivation

async-http-client 1.23.0 compiles with the Swift Static Linux SDK again, so it is no longer necessary to pin to 1.22.1

### Modifications

Updated `Package.resolved` in the Vapor example directory.
Add the example to the NOTICE.txt file.

### Result

The Vapor example builds with the latest versions of its dependencies.

### Test Plan

Built and ran the test example locally.