### PR TITLE
ci: Enable a subset of the unit tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,6 +14,16 @@ jobs:
             license_header_check_project_name: "SwiftContainerPlugin"
             shell_check_container_image: "swift:6.0-noble"
 
+    unit-tests:
+        name: Unit tests
+        uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
+        with:
+            linux_5_8_enabled: false
+            linux_5_9_enabled: false
+            linux_5_10_enabled: false
+            linux_nightly_6_0_arguments_override: "--filter 'AuthTests|ReferenceTests'"
+            linux_nightly_main_arguments_override: "--filter 'AuthTests|ReferenceTests'"
+
     swift-6-language-mode:
         name: Swift 6 Language Mode
         uses: apple/swift-nio/.github/workflows/swift_6_language_mode.yml@main

--- a/Tests/ContainerRegistryTests/ImageReferenceTests.swift
+++ b/Tests/ContainerRegistryTests/ImageReferenceTests.swift
@@ -27,7 +27,7 @@ struct ReferenceTestCase {
 }
 
 class ReferenceTests: XCTestCase {
-    var tests = [
+    let tests = [
         // A reference which does not contain a '/' is always interpreted as a repository name
         // in the default registry.
         ReferenceTestCase(


### PR DESCRIPTION
### Motivation

The smoke tests need a registry as a test fixture.   We don't yet have that but until we do we can still run the other tests.

### Modifications

Enable the `unit-test` shared CI workflow, with a filter.

### Result

A subset of tests will run on each pull request.   This will ensure that the code builds and some functionality is exercised for each pull request.

### Test Plan

Ran the tests locally with `act pull_request`.