### PR TITLE
ContainerRegistry: Switch to swift-http-types

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,12 +26,15 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"4.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
+        .package(url: "https://github.com/apple/swift-http-types.git", from: "1.2.0"),
     ],
     targets: [
         .target(
             name: "ContainerRegistry",
             dependencies: [
                 .product(name: "Crypto", package: "swift-crypto", condition: .when(platforms: [.linux])),
+                .product(name: "HTTPTypes", package: "swift-http-types"),
+                .product(name: "HTTPTypesFoundation", package: "swift-http-types"),
                 .target(
                     name: "Basics"  // AuthorizationProvider
                 ),

--- a/Sources/ContainerRegistry/CheckAPI.swift
+++ b/Sources/ContainerRegistry/CheckAPI.swift
@@ -20,8 +20,11 @@ public extension RegistryClient {
         // The registry may require authentication on this endpoint.
         // See https://github.com/opencontainers/distribution-spec/blob/main/spec.md#determining-support
         do {
-            return try await executeRequestThrowing(.get(registryURLForPath("/v2/")), decodingErrors: [401, 404]).data
-                == EmptyObject()
-        } catch HTTPClientError.unexpectedStatusCode(status: 404, _, _) { return false }
+            return try await executeRequestThrowing(
+                .get(registryURLForPath("/v2/")),
+                decodingErrors: [.unauthorized, .notFound]
+            )
+            .data == EmptyObject()
+        } catch HTTPClientError.unexpectedStatusCode(status: .notFound, _, _) { return false }
     }
 }

--- a/Sources/ContainerRegistry/Manifests.swift
+++ b/Sources/ContainerRegistry/Manifests.swift
@@ -24,11 +24,11 @@ public extension RegistryClient {
                 contentType: "application/vnd.oci.image.manifest.v1+json"
             ),
             uploading: manifest,
-            expectingStatus: 201,
-            decodingErrors: [404]
+            expectingStatus: .created,
+            decodingErrors: [.notFound]
         )
 
-        guard let location = httpResponse.response.value(forHTTPHeaderField: "Location") else {
+        guard let location = httpResponse.response.headerFields[.location] else {
             throw HTTPClientError.missingResponseHeader("Location")
         }
         return location
@@ -46,7 +46,7 @@ public extension RegistryClient {
                     "application/vnd.docker.distribution.manifest.v2+json",
                 ]
             ),
-            decodingErrors: [404]
+            decodingErrors: [.notFound]
         )
         .data
     }
@@ -63,7 +63,7 @@ public extension RegistryClient {
                     "application/vnd.docker.distribution.manifest.list.v2+json",
                 ]
             ),
-            decodingErrors: [404]
+            decodingErrors: [.notFound]
         )
         .data
     }

--- a/Sources/ContainerRegistry/RegistryClient.swift
+++ b/Sources/ContainerRegistry/RegistryClient.swift
@@ -16,7 +16,7 @@ import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
-
+import HTTPTypes
 import Basics
 
 enum RegistryClientError: Error {
@@ -138,10 +138,10 @@ extension RegistryClient {
     /// A plain Data version of this function is required because Data is Decodable and decodes from base64.
     /// Plain blobs are not encoded in the registry, so trying to decode them will fail.
     public func executeRequestThrowing(
-        _ request: URLRequest,
-        expectingStatus success: Int = 200,
-        decodingErrors errors: [Int]
-    ) async throws -> (data: Data, response: HTTPURLResponse) {
+        _ request: HTTPRequest,
+        expectingStatus success: HTTPResponse.Status = .ok,
+        decodingErrors errors: [HTTPResponse.Status]
+    ) async throws -> (data: Data, response: HTTPResponse) {
         do {
             let authenticatedRequest = auth?.auth(for: request) ?? request
             return try await client.executeRequestThrowing(authenticatedRequest, expectingStatus: success)
@@ -167,10 +167,10 @@ extension RegistryClient {
     /// - Returns: An asynchronously-delivered tuple that contains the raw response body as a Data instance, and a HTTPURLResponse.
     /// - Throws: If the server response is unexpected or indicates that an error occurred.
     public func executeRequestThrowing<Response: Decodable>(
-        _ request: URLRequest,
-        expectingStatus success: Int = 200,
-        decodingErrors errors: [Int]
-    ) async throws -> (data: Response, response: HTTPURLResponse) {
+        _ request: HTTPRequest,
+        expectingStatus success: HTTPResponse.Status = .ok,
+        decodingErrors errors: [HTTPResponse.Status]
+    ) async throws -> (data: Response, response: HTTPResponse) {
         let (data, httpResponse) = try await executeRequestThrowing(
             request,
             expectingStatus: success,
@@ -192,11 +192,11 @@ extension RegistryClient {
     /// A plain Data version of this function is required because Data is Encodable and encodes to base64.
     /// Accidentally encoding data blobs will cause digests to fail and runtimes to be unable to run the images.
     public func executeRequestThrowing(
-        _ request: URLRequest,
+        _ request: HTTPRequest,
         uploading payload: Data,
-        expectingStatus success: Int,
-        decodingErrors errors: [Int]
-    ) async throws -> (data: Data, response: HTTPURLResponse) {
+        expectingStatus success: HTTPResponse.Status,
+        decodingErrors errors: [HTTPResponse.Status]
+    ) async throws -> (data: Data, response: HTTPResponse) {
         do {
             let authenticatedRequest = auth?.auth(for: request) ?? request
             return try await client.executeRequestThrowing(
@@ -231,11 +231,11 @@ extension RegistryClient {
     /// - Returns: An asynchronously-delivered tuple that contains the raw response body as a Data instance, and a HTTPURLResponse.
     /// - Throws: If the server response is unexpected or indicates that an error occurred.
     public func executeRequestThrowing<Body: Encodable>(
-        _ request: URLRequest,
+        _ request: HTTPRequest,
         uploading payload: Body,
-        expectingStatus success: Int,
-        decodingErrors errors: [Int]
-    ) async throws -> (data: Data, response: HTTPURLResponse) {
+        expectingStatus success: HTTPResponse.Status,
+        decodingErrors errors: [HTTPResponse.Status]
+    ) async throws -> (data: Data, response: HTTPResponse) {
         try await executeRequestThrowing(
             request,
             uploading: try encoder.encode(payload),

--- a/Sources/containertool/Extensions/Errors+CustomStringConvertible.swift
+++ b/Sources/containertool/Extensions/Errors+CustomStringConvertible.swift
@@ -18,7 +18,6 @@ extension HTTPClientError: Swift.CustomStringConvertible {
     /// A human-readable string representing an underlying HTTP protocol error
     public var description: String {
         switch self {
-        case .nonHTTPResponse: return "Registry response was not valid HTTP"
         case .unexpectedStatusCode(let status, _, _):
             return "Registry returned an unexpected HTTP error code: \(status)"
         case .unexpectedContentType(let contentType):


### PR DESCRIPTION
### Motivation

Swift HTTP Types provides currency types for HTTP clients and servers, which can be used with URLSession and AsyncHTTPClient.

Generally speaking, we try to keep Swift Container Plugin's dependencies to a minimum because each dependency increases the initial build time and also increases the chance of a version conflict with the project which is trying to use the plugin.   However `swift-http-types` is quite a small package and offers some nice ergonomic improvements over `URLRequest`/`URLResponse`, such as enums for HTTP status codes.

### Modifications

Switch all uses of `URLRequest`/`URLResponse` to `HTTPRequest`/`HTTPResponse`

### Result

No functional change.

### Test Plan

The unit and integration tests continue to pass.