### PR TITLE
ci: Enable smoke tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,8 +21,35 @@ jobs:
             linux_5_8_enabled: false
             linux_5_9_enabled: false
             linux_5_10_enabled: false
-            linux_nightly_6_0_arguments_override: "--filter 'AuthTests|ReferenceTests'"
-            linux_nightly_main_arguments_override: "--filter 'AuthTests|ReferenceTests'"
+            linux_nightly_6_0_arguments_override: "--skip SmokeTests"
+            linux_nightly_main_arguments_override: "--skip SmokeTests"
+
+    integration-tests:
+        name: Integration tests
+        runs-on: ubuntu-latest
+        services:
+            registry:
+                image: registry:2
+                ports:
+                - 5000:5000
+        container:
+            image: swift:6.0-noble
+        steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
+          with:
+              persist-credentials: false
+
+        - name: Mark the workspace as safe
+          # https://github.com/actions/checkout/issues/766
+          run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
+        - name: Run test job
+          env:
+              REGISTRY_HOST: registry
+              REGISTRY_PORT: 5000
+          run: |
+              swift test
 
     swift-6-language-mode:
         name: Swift 6 Language Mode

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -67,6 +67,12 @@ function from SwiftNIO Extras.
 This product contains samples of how to use Swift Container Plugin with the
 following other projects:
 
+  * Distribution Registry
+    * LICENSE (Apache License 2.0):
+      * https://www.apache.org/licenses/LICENSE-2.0
+    * HOMEPAGE:
+      * https://github.com/distribution/distribution
+
   * Vapor
     * LICENSE (MIT License):
       * https://mit-license.org

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftContainerPlugin open source project
+##
+## Copyright (c) 2024 Apple Inc. and the SwiftContainerPlugin project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftContainerPlugin project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+
+log() { printf -- "** %s\n" "$*" >&2; }
+error() { printf -- "** ERROR: %s\n" "$*" >&2; }
+fatal() { error "$@"; exit 1; }
+
+if [[ -n ${TOOLCHAINS+x} ]] ; then
+    fatal "Please unset the TOOLCHAINS environment variable.   The OSS Swift toolchain cannot run these tests because it does not include XCTest.framework."
+fi
+
+set -euo pipefail
+
+RUNTIME=${RUNTIME-"docker"}
+
+# Start a registry on an ephemeral port
+REGISTRY_ID=$($RUNTIME run -d --rm -p 127.0.0.1::5000 registry:2)
+export REGISTRY_HOST="localhost"
+REGISTRY_PORT=$($RUNTIME port "$REGISTRY_ID" 5000/tcp | sed -E 's/^.+:([[:digit:]]+)$/\1/')
+export REGISTRY_PORT
+log "Registry $REGISTRY_ID listening on $REGISTRY_HOST:$REGISTRY_PORT"
+
+# Delete the registry after running the tests, regardless of the outcome
+cleanup() {
+  log "Deleting registry $REGISTRY_ID"
+  $RUNTIME rm -f "$REGISTRY_ID"
+}
+trap cleanup EXIT
+
+log "Running smoke tests"
+swift test --filter 'SmokeTests'


### PR DESCRIPTION
### Motivation

The integration tests (`SmokeTests`) are not currently run on PRs because they require an instance of the container registry to be available.

### Modifications

Add a custom job which runs `registry` as a service container.

### Result

Integration tests will be run for every pull request.   The integration test job also runs the tests run by the unit tests job, but the duplication is not very costly. 
### Test Plan

All tests continue to pass.