### PR TITLE
Readme: Add Swift Package Index badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Swift Container Plugin
 
+[![](https://img.shields.io/badge/docc-read_documentation-blue)](https://swiftpackageindex.com/apple/swift-container-plugin/documentation/containerimagebuilderplugin)
+[![](https://img.shields.io/github/v/release/apple/swift-container-plugin?include_prereleases)](https://github.com/apple/swift-container-plugin/releases)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fapple%2Fswift-container-plugin%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/apple/swift-container-plugin)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fapple%2Fswift-container-plugin%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/apple/swift-container-plugin)
+
 Publish container images using Swift Package Manager.
 
 Learn more about Swift Container Plugin in the [lightning talk](https://www.youtube.com/watch?v=9AaINsCfZzw) from [ServerSide.Swift 2024](https://www.serversideswift.info/speakers/euan-harris/).


### PR DESCRIPTION
The package is now indexed by Swift Package Index, so we can link to the DocC-generated documentation pages hosted there.