### PR TITLE
containertool: Use the default registry parameter for image uploads

### DIFF
--- a/Sources/containertool/containertool.swift
+++ b/Sources/containertool/containertool.swift
@@ -60,7 +60,7 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
 
     func run() async throws {
         let baseimage = try ImageReference(fromString: from, defaultRegistry: defaultRegistry)
-        var destination_image = try ImageReference(fromString: repository)
+        var destination_image = try ImageReference(fromString: repository, defaultRegistry: defaultRegistry)
 
         let authProvider: AuthorizationProvider?
         if !netrc {


### PR DESCRIPTION
### Motivation

The `--default-registry` parameter (also set by the `CONTAINERTOOL_DEFAULT_REGISTRY` environment variable) allows a default registry address to be specified for unqualified image names.   For example, the following uploads should be equivalent:

`containertool --default-registry myregistry.com --repository myrepo/myimage --from baserepo/baseimage`
`containertool --repository myregistry.com/myrepo/myimage --from baserepo/baseimage`

However the default registry was only being applied when fetching the base image (the `--from` parameter) and not when pushing the final image (the `--repository` parameter).

### Modifications

The default registry parameter is now used when pushing the final image.

### Result

Pushes to unqualified repositories will work properly.

### Test Plan

Manually tested `containertool` uploads with a variety of qualified and unqualified image names.