### PR TITLE
ci: Use the shared soundness workflow from swiftlang/github-workflows

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,7 +2,7 @@ name: PR
 
 on:
     pull_request:
-      types: [opened, reopened, synchronize]
+        types: [opened, reopened, synchronize]
 
 jobs:
     soundness:
@@ -31,25 +31,25 @@ jobs:
             registry:
                 image: registry:2
                 ports:
-                - 5000:5000
+                    - 5000:5000
         container:
             image: swift:6.0-noble
         steps:
-        - name: Checkout repository
-          uses: actions/checkout@v4
-          with:
-              persist-credentials: false
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
 
-        - name: Mark the workspace as safe
-          # https://github.com/actions/checkout/issues/766
-          run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+            - name: Mark the workspace as safe
+              # https://github.com/actions/checkout/issues/766
+              run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
-        - name: Run test job
-          env:
-              REGISTRY_HOST: registry
-              REGISTRY_PORT: 5000
-          run: |
-              swift test
+            - name: Run test job
+              env:
+                  REGISTRY_HOST: registry
+                  REGISTRY_PORT: 5000
+              run: |
+                  swift test
 
     swift-6-language-mode:
         name: Swift 6 Language Mode

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ on:
 jobs:
     soundness:
         name: Soundness
-        uses: apple/swift-nio/.github/workflows/soundness.yml@main
+        uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
         with:
             api_breakage_check_container_image: "swift:6.0-noble"
             docs_check_container_image: "swift:6.0-noble"

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,6 +1,6 @@
 version: 1
 builder:
   configs:
-  - documentation_targets:
-    - containertool
-    - ContainerImageBuilderPlugin
+    - documentation_targets:
+        - containertool
+        - ContainerImageBuilderPlugin


### PR DESCRIPTION
### Motivation

`swiftlang/github-workflows` is the final home for the shared soundness workflows which started in `apple/swift-nio`.

### Modifications

Use the soundness workflow from `swiftlang/github-workflows`.
Fix complaints from the new YAML linter step.

### Result

We will pull the shared workflow from the correct final location, so we will continue to receive updates.

### Test Plan

CI continues to pass.