### PR TITLE
ContainerRegistry: Fix a few requests which were not using swift-http-types error codes 

### DIFF
--- a/Sources/ContainerRegistry/Blobs.swift
+++ b/Sources/ContainerRegistry/Blobs.swift
@@ -64,7 +64,7 @@ public extension RegistryClient {
         do {
             let _ = try await executeRequestThrowing(
                 .head(registryURLForPath("/v2/\(repository)/blobs/\(digest)")),
-                decodingErrors: [404]
+                decodingErrors: [.notFound]
             )
             return true
         } catch HTTPClientError.unexpectedStatusCode(status: .notFound, _, _) { return false }
@@ -83,7 +83,7 @@ public extension RegistryClient {
 
         return try await executeRequestThrowing(
             .get(registryURLForPath("/v2/\(repository)/blobs/\(digest)"), accepting: ["application/octet-stream"]),
-            decodingErrors: [404]
+            decodingErrors: [.notFound]
         )
         .data
     }
@@ -106,7 +106,7 @@ public extension RegistryClient {
 
         return try await executeRequestThrowing(
             .get(registryURLForPath("/v2/\(repository)/blobs/\(digest)"), accepting: ["application/octet-stream"]),
-            decodingErrors: [404]
+            decodingErrors: [.notFound]
         )
         .data
     }

--- a/Sources/ContainerRegistry/Tags.swift
+++ b/Sources/ContainerRegistry/Tags.swift
@@ -18,7 +18,7 @@ public extension RegistryClient {
         precondition(repository.count > 0, "repository must not be an empty string")
         return try await executeRequestThrowing(
             .get(registryURLForPath("/v2/\(repository)/tags/list")),
-            decodingErrors: [404]
+            decodingErrors: [.notFound]
         )
         .data
     }


### PR DESCRIPTION
### Motivation

`swift-http-types` provides enums giving readable names for HTTP error codes.   We should use these enums everewhere.

### Modifications

Fix a few places where raw HTTP error codes were still being used.

### Result

The code is more consistent.   No functional change.

### Test Plan

Tests continue to pass.