### PR TITLE
ci: Remove Linux 5.8 configuration

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,9 +18,9 @@ jobs:
         name: Unit tests
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
-            linux_5_8_enabled: false
             linux_5_9_enabled: false
             linux_5_10_enabled: false
+            linux_6_0_arguments_override: "--skip SmokeTests"
             linux_nightly_6_0_arguments_override: "--skip SmokeTests"
             linux_nightly_main_arguments_override: "--skip SmokeTests"
 


### PR DESCRIPTION
### Motivation

Upstream has removed the 5.8 configuration, so setting it causes the runners to fail.

https://github.com/apple/swift-nio/commit/c16420c4a7e026174e4eb373953a8eae41a7a4a8#diff-c91058a32040621ac54d6ea4194b302a420b7849f6e8561920d23a0e97acf69a

### Modifications

Remove Swift 5.8 configuration, add Swift 6.0 configuration.

### Result

Actions will run again.   Currently they fail with 'startup error'.

### Test Plan

Check that actions-based tests can start again.