### PR TITLE
ContainerRegistry: A /v2/ protocol check response is allowed to be empty

### DIFF
--- a/Sources/ContainerRegistry/CheckAPI.swift
+++ b/Sources/ContainerRegistry/CheckAPI.swift
@@ -16,15 +16,17 @@ public extension RegistryClient {
     /// Returns a boolean value indicating whether the registry supports v2 of the distribution specification.
     /// - Returns: `true` if the registry supports the distribution specification, otherwise `false`.
     func checkAPI() async throws -> Bool {
-        // The registry indicates that it supports the v2 protocol by returning an empty JSON object i.e. {}.
-        // The registry may require authentication on this endpoint.
         // See https://github.com/opencontainers/distribution-spec/blob/main/spec.md#determining-support
+        // The registry indicates that it supports the v2 protocol by returning a 200 OK response.
+        // Many registries also set `Content-Type: application/json` and return empty JSON objects,
+        // but this is not required and some do not.
+        // The registry may require authentication on this endpoint.
         do {
-            return try await executeRequestThrowing(
+            let _ = try await executeRequestThrowing(
                 .get(registryURLForPath("/v2/")),
                 decodingErrors: [.unauthorized, .notFound]
             )
-            .data == EmptyObject()
+            return true
         } catch HTTPClientError.unexpectedStatusCode(status: .notFound, _, _) { return false }
     }
 }


### PR DESCRIPTION
### Motivation

The registry indicates that it supports the v2 protocol by returning a [200 OK response](See https://github.com/opencontainers/distribution-spec/blob/main/spec.md#determining-support)

Many registries also set `Content-Type: application/json` and return empty JSON objects in their responses but this is not required and some, such as ECR, return empty responses.

### Modifications

Do not require the API check response to contain an empty JSON object.
 
### Result

Pushing to ECR will no longer fail with an `"The given data was not valid JSON."` error message. 

### Test Plan

Automated tests continue to pass, tested manually with ECR.