### PR TITLE
ContainerRegistry: Tolerate missing Content-Type header in registry response

### DIFF
--- a/Sources/ContainerRegistry/HTTPClient.swift
+++ b/Sources/ContainerRegistry/HTTPClient.swift
@@ -81,12 +81,6 @@ extension URLSession: HTTPClient {
                 }
             }
 
-            // Content-Type should always be set, but there may be registries which don't set it.   If it is not present, the HTTP standard allows
-            // clients to guess the content type, or default to `application/octet-stream'.
-            guard let _ = response.headerFields[.contentType] else {
-                throw HTTPClientError.missingResponseHeader("Content-Type")
-            }
-
             // A HEAD request has no response body and cannot be decoded
             if request.method == .head {
                 throw HTTPClientError.unexpectedStatusCode(status: response.status, response: response, data: nil)


### PR DESCRIPTION
### Motivation

ECR does not set the `Content-Type` header in its response to a blob upload.    If it is not present, the HTTP standard allows clients to guess the content type, or default to `application/octet-stream'.    In this case, knowing the content type is not critical so there is no need to check for it.

### Modifications

Do not check that responses contain the `Content-Type` header in the low-level HTTP client.

### Result

Blob uploads to ECR will not fail.

### Test Plan

Automated tests continue to pass; tested manually with ECR.