### PR TITLE
ContainerRegistry: Add a struct to represent a registry operation

### DIFF
--- a/Sources/ContainerRegistry/Blobs.swift
+++ b/Sources/ContainerRegistry/Blobs.swift
@@ -41,7 +41,7 @@ extension RegistryClient {
         // - Do not include the digest.
         // Response will include a 'Location' header telling us where to PUT the blob data.
         let httpResponse = try await executeRequestThrowing(
-            .post(registryURLForPath("/v2/\(repository)/blobs/uploads/")),
+            .post(repository, path: "blobs/uploads/"),
             expectingStatus: .accepted,  // expected response code for a "two-shot" upload
             decodingErrors: [.notFound]
         )
@@ -63,7 +63,7 @@ public extension RegistryClient {
 
         do {
             let _ = try await executeRequestThrowing(
-                .head(registryURLForPath("/v2/\(repository)/blobs/\(digest)")),
+                .head(repository, path: "blobs/\(digest)"),
                 decodingErrors: [.notFound]
             )
             return true
@@ -82,7 +82,7 @@ public extension RegistryClient {
         precondition(digest.count > 0, "digest must not be an empty string")
 
         return try await executeRequestThrowing(
-            .get(registryURLForPath("/v2/\(repository)/blobs/\(digest)"), accepting: ["application/octet-stream"]),
+            .get(repository, path: "blobs/\(digest)", accepting: ["application/octet-stream"]),
             decodingErrors: [.notFound]
         )
         .data
@@ -105,7 +105,7 @@ public extension RegistryClient {
         precondition(digest.count > 0, "digest must not be an empty string")
 
         return try await executeRequestThrowing(
-            .get(registryURLForPath("/v2/\(repository)/blobs/\(digest)"), accepting: ["application/octet-stream"]),
+            .get(repository, path: "blobs/\(digest)", accepting: ["application/octet-stream"]),
             decodingErrors: [.notFound]
         )
         .data
@@ -136,10 +136,9 @@ public extension RegistryClient {
         let digest = digest(of: data)
         location.queryItems = (location.queryItems ?? []) + [URLQueryItem(name: "digest", value: "\(digest.utf8)")]
         guard let uploadURL = location.url else { throw RegistryClientError.invalidUploadLocation("\(location)") }
-
         let httpResponse = try await executeRequestThrowing(
             // All blob uploads have Content-Type: application/octet-stream on the wire, even if mediatype is different
-            .put(uploadURL, contentType: "application/octet-stream"),
+            .put(repository, url: uploadURL, contentType: "application/octet-stream"),
             uploading: data,
             expectingStatus: .created,
             decodingErrors: [.badRequest, .notFound]

--- a/Sources/ContainerRegistry/CheckAPI.swift
+++ b/Sources/ContainerRegistry/CheckAPI.swift
@@ -22,8 +22,10 @@ public extension RegistryClient {
         // but this is not required and some do not.
         // The registry may require authentication on this endpoint.
         do {
+            // Using the bare HTTP client because this is the only endpoint which does not include a repository path
             let _ = try await executeRequestThrowing(
-                .get(registryURLForPath("/v2/")),
+                .get("", url: registryURL.distributionEndpoint),
+                expectingStatus: .ok,
                 decodingErrors: [.unauthorized, .notFound]
             )
             return true

--- a/Sources/ContainerRegistry/HTTPClient.swift
+++ b/Sources/ContainerRegistry/HTTPClient.swift
@@ -159,40 +159,4 @@ extension HTTPRequest {
         //    https://developer.apple.com/forums/thread/89811
         if let authorization { headerFields[.authorization] = authorization }
     }
-
-    static func get(
-        _ url: URL,
-        accepting: [String] = [],
-        contentType: String? = nil,
-        withAuthorization authorization: String? = nil
-    ) -> HTTPRequest {
-        .init(method: .get, url: url, accepting: accepting, contentType: contentType, withAuthorization: authorization)
-    }
-
-    static func head(
-        _ url: URL,
-        accepting: [String] = [],
-        contentType: String? = nil,
-        withAuthorization authorization: String? = nil
-    ) -> HTTPRequest {
-        .init(method: .head, url: url, accepting: accepting, contentType: contentType, withAuthorization: authorization)
-    }
-
-    static func put(
-        _ url: URL,
-        accepting: [String] = [],
-        contentType: String? = nil,
-        withAuthorization authorization: String? = nil
-    ) -> HTTPRequest {
-        .init(method: .put, url: url, accepting: accepting, contentType: contentType, withAuthorization: authorization)
-    }
-
-    static func post(
-        _ url: URL,
-        accepting: [String] = [],
-        contentType: String? = nil,
-        withAuthorization authorization: String? = nil
-    ) -> HTTPRequest {
-        .init(method: .post, url: url, accepting: accepting, contentType: contentType, withAuthorization: authorization)
-    }
 }

--- a/Sources/ContainerRegistry/Manifests.swift
+++ b/Sources/ContainerRegistry/Manifests.swift
@@ -21,7 +21,8 @@ public extension RegistryClient {
         let httpResponse = try await executeRequestThrowing(
             // All blob uploads have Content-Type: application/octet-stream on the wire, even if mediatype is different
             .put(
-                registryURLForPath("/v2/\(repository)/manifests/\(reference)"),
+                repository,
+                path: "manifests/\(reference)",
                 contentType: manifest.mediaType ?? "application/vnd.oci.image.manifest.v1+json"
             ),
             uploading: manifest,
@@ -35,8 +36,9 @@ public extension RegistryClient {
         // ECR does not set this header at all.
         // If the header is not present, create a suitable value.
         // https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests
-        return try httpResponse.response.headerFields[.location]
-            ?? registryURLForPath("/v2/\(repository)/manifests/\(manifest.digest)").absoluteString
+        return httpResponse.response.headerFields[.location]
+            ?? registryURL.distributionEndpoint(forRepository: repository, andEndpoint: "manifests/\(manifest.digest)")
+            .absoluteString
     }
 
     func getManifest(repository: String, reference: String) async throws -> ImageManifest {
@@ -46,7 +48,8 @@ public extension RegistryClient {
 
         return try await executeRequestThrowing(
             .get(
-                registryURLForPath("/v2/\(repository)/manifests/\(reference)"),
+                repository,
+                path: "manifests/\(reference)",
                 accepting: [
                     "application/vnd.oci.image.manifest.v1+json",
                     "application/vnd.docker.distribution.manifest.v2+json",
@@ -63,7 +66,8 @@ public extension RegistryClient {
 
         return try await executeRequestThrowing(
             .get(
-                registryURLForPath("/v2/\(repository)/manifests/\(reference)"),
+                repository,
+                path: "manifests/\(reference)",
                 accepting: [
                     "application/vnd.oci.image.index.v1+json",
                     "application/vnd.docker.distribution.manifest.list.v2+json",

--- a/Sources/ContainerRegistry/Tags.swift
+++ b/Sources/ContainerRegistry/Tags.swift
@@ -16,10 +16,7 @@ public extension RegistryClient {
     func getTags(repository: String) async throws -> Tags {
         // See https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-tags
         precondition(repository.count > 0, "repository must not be an empty string")
-        return try await executeRequestThrowing(
-            .get(registryURLForPath("/v2/\(repository)/tags/list")),
-            decodingErrors: [.notFound]
-        )
-        .data
+
+        return try await executeRequestThrowing(.get(repository, path: "tags/list"), decodingErrors: [.notFound]).data
     }
 }


### PR DESCRIPTION
### Motivation

`RegistryClient.executeRequestThrowing` currently takes an `HTTPRequest` struct parameter and executes it using the underlying `HTTPClient`.   It augments `HTTPClient` by handling authentication challenges and decodes JSON error responses, but the use of `HTTPRequest` means that the caller is responsible for details such as generating the full distribution endpoint URL.   Giving `RegistryClient` its own abstract operation type frees the caller from dealing with these internal details.

The struct can also be passed easily anywhere the details of the operation are required, making future improvements easier.   For instance, if an operation causes an error, the original operation struct could be attached to the error making all its details available to the error handler.

### Modifications

Add a struct which holds all the necessary information about a requested operation on the registry, and refactor `RegistryClient` to use it.

### Result

No functional change.

This refactoring makes the separation of RegistryClient and HTTPClient's responsibilities clearer, and allows us to centralise the generation of registry URLs.  In the future it will make further improvements easier, such as changing how authentication is handled and providing more detailed error messages.

### Test Plan

Automated tests continue to pass; also tested manually.