### PR TITLE
ContainerRegistry: Remember initial auth challenge and send credentials eagerly

### DIFF
--- a/Sources/ContainerRegistry/HTTPClient.swift
+++ b/Sources/ContainerRegistry/HTTPClient.swift
@@ -159,4 +159,13 @@ extension HTTPRequest {
         //    https://developer.apple.com/forums/thread/89811
         if let authorization { headerFields[.authorization] = authorization }
     }
+
+    static func get(
+        _ url: URL,
+        accepting: [String] = [],
+        contentType: String? = nil,
+        withAuthorization authorization: String? = nil
+    ) -> HTTPRequest {
+        .init(method: .get, url: url, accepting: accepting, contentType: contentType, withAuthorization: authorization)
+    }
 }

--- a/Tests/ContainerRegistryTests/AuthTests.swift
+++ b/Tests/ContainerRegistryTests/AuthTests.swift
@@ -16,7 +16,7 @@ import Foundation
 import Basics
 import XCTest
 
-class AuthTests: XCTestCase {
+class AuthTests: XCTestCase, @unchecked Sendable {
     // SwiftPM's NetrcAuthorizationProvider does not throw an error if the .netrc file
     // does not exist.   For simplicity the local vendored version does the same.
     func testNonexistentNetrc() async throws {

--- a/Tests/ContainerRegistryTests/SmokeTests.swift
+++ b/Tests/ContainerRegistryTests/SmokeTests.swift
@@ -16,7 +16,7 @@ import Foundation
 import ContainerRegistry
 import XCTest
 
-class SmokeTests: XCTestCase {
+class SmokeTests: XCTestCase, @unchecked Sendable {
     // These are basic tests to exercise the main registry operations.
     // The tests assume that a fresh, empty registry instance is available at
     // http://$REGISTRY_HOST:$REGISTRY_PORT
@@ -29,11 +29,6 @@ class SmokeTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
         client = try await RegistryClient(registry: "\(registryHost):\(registryPort)", insecure: true)
-    }
-
-    func testCheckAPI() async throws {
-        let supported = try await client.checkAPI()
-        XCTAssert(supported)
     }
 
     func testGetTags() async throws {


### PR DESCRIPTION
### Motivation

Currently, `ContainerRegistry` handles authentication lazily.   First it tries an unauthenticated request.   If the registry responds with a challenge, `ContainerRegistry` gets a suitable credential from `.netrc` or from an authentication service and re-tries the request.

When pushing large blobs to some registries, the client can get stuck in a state where it has received an authentication challenge but is still waiting to finish the blob upload.   The symptoms are that metadata uploads and very small image layers can be uploaded, but pushing larger images stalls and times out, as reported in #17.

### Modifications

When pushing large blobs, the registry's `401` challenge arrives after the client has sent some of the blob data, but before it has completed the upload.   With some registries, `URLSession` gets stuck in this state.   Implementing the `didReceiveResponse` delegate allows the client to see the challenge and cancel the task but in some cases, mainly on Linux, `URLSession` can still get stuck.

A more reliable solution to this problem is to handle challenges eagerly.   Before pushing any data, the client checks whether the registry supports the v2 distribution protocol.  If it is challenged during this check, it will then eagerly send a suitable authentication token with all subsequent requests to the registry.   This avoids the state where the client receives a challenge part-way through uploading a large blob and gets stuck.

### Result

It is possible to upload large images to ECR and Docker Hub from macOS hosts, and to Docker Hub from Linux hosts.   Uploading to ECR from Linux hosts continues to lead to a timeout.

Fixes #17 

### Test Plan

Automated tests continue to pass;  tested manually with several different registries.
