### PR TITLE
containertool: Date.now.ISO8601Format is available on Linux on Swift 6.0

### DIFF
--- a/Sources/containertool/containertool.swift
+++ b/Sources/containertool/containertool.swift
@@ -144,9 +144,7 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
 
         // MARK: Create the application configuration
 
-        // The more convenient Date.now.ISO8601Format() is not present on Linux
-        let formatter = ISO8601DateFormatter()
-        let now = formatter.string(from: Date.now)
+        let now = Date.now.ISO8601Format()
 
         // Inherit the configuration of the base image - UID, GID, environment etc -
         // and override the entrypoint.


### PR DESCRIPTION
### Motivation

The convenient `Date.now.ISO8601Format()` method was not present on Linux in earlier versions of Swift, but is available in Swift 6.0.

### Modifications

Use `Date.now.ISO8601Format()` instead of creating a separate formatter.

### Result

No functional change.

### Test Plan

Tests continue to pass.