### PR TITLE
ContainerRegistry: Unconditionally depend on swift-crypto

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,20 +32,16 @@ let package = Package(
         .target(
             name: "ContainerRegistry",
             dependencies: [
-                .product(name: "Crypto", package: "swift-crypto", condition: .when(platforms: [.linux])),
+                .target(name: "Basics"), .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "HTTPTypes", package: "swift-http-types"),
                 .product(name: "HTTPTypesFoundation", package: "swift-http-types"),
-                .target(
-                    name: "Basics"  // AuthorizationProvider
-                ),
             ]
         ),
         .executableTarget(
             name: "containertool",
             dependencies: [
-                .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "Crypto", package: "swift-crypto", condition: .when(platforms: [.linux])),
                 .target(name: "ContainerRegistry"), .target(name: "VendorCNIOExtrasZlib"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),

--- a/Sources/ContainerRegistry/Blobs.swift
+++ b/Sources/ContainerRegistry/Blobs.swift
@@ -14,12 +14,7 @@
 
 import Foundation
 import HTTPTypes
-
-#if canImport(CryptoKit)
-import CryptoKit
-#else
 import Crypto
-#endif
 
 /// Calculates the digest of a blob of data.
 /// - Parameter data: Blob of data to digest.

--- a/Sources/ContainerRegistry/ImageManifest+Digest.swift
+++ b/Sources/ContainerRegistry/ImageManifest+Digest.swift
@@ -13,12 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-
-#if canImport(CryptoKit)
-import CryptoKit
-#else
 import Crypto
-#endif
 
 public extension ImageManifest {
     var digest: String {


### PR DESCRIPTION
### Motivation

`swift-crypto` provides a common cryptography interface on macOS and Linux.   On macOS it defers to CryptoKit, and although the files in the library must all be processed the compilation time is minimal.

In the past, on slower machines, avoiding processing `swift-crypto` on macOS seemed to improve build times by a few seconds.   Currently the cost of processing these files is negligible, and using `swift-crypto` on Linux and macOS allows conditional includes to be removed.

### Modifications

Always depend on `swift-crypto` in `Package.swift`
Replace conditional imports of `CryptoKit` with unconditional imports of `Crypto`.

### Result

No functional change.

### Test Plan

Automated tests continue to pass.