### PR TITLE
github: Use alternative heading syntax in pull request template 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,19 @@
-### Motivation
+Motivation
+----------
 
 _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_
 
-### Modifications
+Modifications
+-------------
 
 _[Describe the modifications you've made.]_
 
-### Result
+Result
+------
 
 _[After your change, what will change.]_
 
-### Test Plan
+Test Plan
+---------
 
 _[Describe the steps you took, or will take, to qualify the change - such as adjusting tests and manual testing.]_


### PR DESCRIPTION
Motivation
----------

The Git CLI ignores commit message lines starting with # as comments,
so editing commits causes heading lines starting ### to be lost.

Modifications
-------------

Change the pull request template to use underlines instead of ###.

Result
------

Headings will not be lost when commits are edited using the `git` CLI.
Headings will now be H2 rather than H3, because there is no alternative
syntax for H3.

Test Plan
---------

Submitted this PR using the new syntax.