### PR TITLE
tests: Build and run examples as end to end tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -51,6 +51,55 @@ jobs:
               run: |
                   swift test
 
+    endtoend-tests:
+        name: End to end tests
+        runs-on: ubuntu-latest
+        services:
+            registry:
+                image: registry:2
+                ports:
+                    - 5000:5000
+        strategy:
+            matrix:
+                example:
+                    - Examples/HelloWorldVapor
+                    - Examples/HelloWorldHummingbird
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
+
+            - name: Mark the workspace as safe
+              # https://github.com/actions/checkout/issues/766
+              run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
+            - name: Install the static SDK
+              run: |
+                  swift sdk install \
+                      https://download.swift.org/swift-6.0.2-release/static-sdk/swift-6.0.2-RELEASE/swift-6.0.2-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz \
+                      --checksum aa5515476a403797223fc2aad4ca0c3bf83995d5427fb297cab1d93c68cee075
+
+            - name: Build the example
+              run: |
+                  sed -i'.bak' -e "/swift-container-plugin/ s@(url:.*),@(path: \"$PWD\"),@" ${{ matrix.example }}/Package.swift   # Use plugin from this checkout
+                  cat ${{ matrix.example }}/Package.swift
+                  swift package \
+                      --package-path ${{ matrix.example }} \
+                      --swift-sdk x86_64-swift-linux-musl \
+                      --allow-network-connections all \
+                      build-container-image \
+                      --repository localhost:5000/example \
+                      --from scratch
+
+            - name: Run the example
+              run: |
+                  docker run -d --platform linux/amd64 -p 8080:8080 localhost:5000/example
+
+            - name: Check that the service is running
+              run: |
+                  curl -v localhost:8080 | grep "Hello World"
+
     swift-6-language-mode:
         name: Swift 6 Language Mode
         uses: apple/swift-nio/.github/workflows/swift_6_language_mode.yml@main

--- a/Examples/HelloWorldHummingbird/Package.swift
+++ b/Examples/HelloWorldHummingbird/Package.swift
@@ -26,5 +26,4 @@ let package = Package(
     targets: [
         .executableTarget(name: "hello-world", dependencies: [.product(name: "Hummingbird", package: "hummingbird")])
     ]
-
 )


### PR DESCRIPTION
Motivation
----------

For each pull request, the CI runs a number of test suites:

* Soundness: these are static checks of formatting, language and so on
* Unit tests: these check individual library functions in isolation
* Integration tests: these check individual registry library functions against a test registry instance
* Swift 6 Language Mode: this checks that the project compiles with Swift 6

These are all unit or integration tests;  there are no complete system tests to exercise the `build-container-image` plugin, or that the examples work.   It is difficult to test the `build-container-image` plugin in XCTest, but with GitHub Actions we can work through all the steps of building and deploying one of the examples, including using a Swift SDK.    This will cover all the major parts of the project and ensure that the examples continue to work.

Modifications
-------------

This commit adds a new GitHub Actions test which:
* Installs the static Linux SDK
* Uses it to build an example service
* Publishes the example image to a registry running in a service container
* Deploys the image using Docker provided by the GitHub Actions runner
* Verifies that the example service works

Result
------

An end-to-end build and deployment of one of the examples will be attempted for every pull request.

Test Plan
---------

This commit adds a new test, which passes.   All existing tests continue to pass.