### PR TITLE
tests: Mechanically convert to swift-testing

### DIFF
--- a/Tests/ContainerRegistryTests/AuthTests.swift
+++ b/Tests/ContainerRegistryTests/AuthTests.swift
@@ -12,79 +12,87 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Basics
-import XCTest
+import Foundation
+import Testing
 
-class AuthTests: XCTestCase, @unchecked Sendable {
+struct AuthTests {
     // SwiftPM's NetrcAuthorizationProvider does not throw an error if the .netrc file
     // does not exist.   For simplicity the local vendored version does the same.
-    func testNonexistentNetrc() async throws {
+    @Test func testNonexistentNetrc() async throws {
         // Construct a URL to a nonexistent file in the bundle directory
         let netrcURL = Bundle.module.resourceURL!.appendingPathComponent("netrc.nonexistent")
-        XCTAssertFalse(FileManager.default.fileExists(atPath: netrcURL.path))
+        #expect(!FileManager.default.fileExists(atPath: netrcURL.path))
 
         let authProvider = try NetrcAuthorizationProvider(netrcURL)
-        XCTAssertNil(authProvider.authentication(for: URL(string: "https://hub.example.com")!))
+        #expect(authProvider.authentication(for: URL(string: "https://hub.example.com")!) == nil)
     }
 
-    func testEmptyNetrc() async throws {
+    @Test func testEmptyNetrc() async throws {
         let netrcURL = Bundle.module.url(forResource: "netrc", withExtension: "empty")!
         let authProvider = try NetrcAuthorizationProvider(netrcURL)
-        XCTAssertNil(authProvider.authentication(for: URL(string: "https://hub.example.com")!))
+        #expect(authProvider.authentication(for: URL(string: "https://hub.example.com")!) == nil)
     }
 
-    func testBasicNetrc() async throws {
+    @Test func testBasicNetrc() async throws {
         let netrcURL = Bundle.module.url(forResource: "netrc", withExtension: "basic")!
         let authProvider = try NetrcAuthorizationProvider(netrcURL)
-        XCTAssertNil(authProvider.authentication(for: URL(string: "https://nothing.example.com")!))
+        #expect(authProvider.authentication(for: URL(string: "https://nothing.example.com")!) == nil)
 
         guard let (user, password) = authProvider.authentication(for: URL(string: "https://hub.example.com")!) else {
-            return XCTFail("Expected to find a username and password")
+            Issue.record("Expected to find a username and password")
+            return
         }
-        XCTAssertEqual(user, "swift")
-        XCTAssertEqual(password, "password")
+        #expect(user == "swift")
+        #expect(password == "password")
     }
 
     // The default entry is used if no specific entry matches
-    func testComplexNetrcWithDefault() async throws {
+    @Test func testComplexNetrcWithDefault() async throws {
         let netrcURL = Bundle.module.url(forResource: "netrc", withExtension: "default")!
         let authProvider = try NetrcAuthorizationProvider(netrcURL)
 
         guard let (user, password) = authProvider.authentication(for: URL(string: "https://nothing.example.com")!)
-        else { return XCTFail("Expected to find a username and password") }
-        XCTAssertEqual(user, "defaultlogin")
-        XCTAssertEqual(password, "defaultpassword")
+        else {
+            Issue.record("Expected to find a username and password")
+            return
+        }
+        #expect(user == "defaultlogin")
+        #expect(password == "defaultpassword")
     }
 
     // The default entry must be last in the file
-    func testComplexNetrcWithInvalidDefault() async throws {
+    @Test func testComplexNetrcWithInvalidDefault() async throws {
         let netrcURL = Bundle.module.url(forResource: "netrc", withExtension: "invaliddefault")!
-        XCTAssertThrowsError(try NetrcAuthorizationProvider(netrcURL)) { error in
-            XCTAssertEqual(error as! NetrcError, NetrcError.invalidDefaultMachinePosition)
+        #expect { try NetrcAuthorizationProvider(netrcURL) } throws: { error in
+            error as! NetrcError == NetrcError.invalidDefaultMachinePosition
         }
     }
 
     // If there are multiple entries for the same host, the last one wins
-    func testComplexNetrcOverriddenEntry() async throws {
+    @Test func testComplexNetrcOverriddenEntry() async throws {
         let netrcURL = Bundle.module.url(forResource: "netrc", withExtension: "default")!
         let authProvider = try NetrcAuthorizationProvider(netrcURL)
 
         guard let (user, password) = authProvider.authentication(for: URL(string: "https://hub.example.com")!) else {
-            return XCTFail("Expected to find a username and password")
+            Issue.record("Expected to find a username and password")
+            return
         }
-        XCTAssertEqual(user, "swift2")
-        XCTAssertEqual(password, "password2")
+        #expect(user == "swift2")
+        #expect(password == "password2")
     }
 
     // A singleton entry in a netrc file with defaults and overriden entries continues to work as in the simple case
-    func testComplexNetrcSingletonEntry() async throws {
+    @Test func testComplexNetrcSingletonEntry() async throws {
         let netrcURL = Bundle.module.url(forResource: "netrc", withExtension: "default")!
         let authProvider = try NetrcAuthorizationProvider(netrcURL)
 
         guard let (user, password) = authProvider.authentication(for: URL(string: "https://another.example.com")!)
-        else { return XCTFail("Expected to find a username and password") }
-        XCTAssertEqual(user, "anotherlogin")
-        XCTAssertEqual(password, "anotherpassword")
+        else {
+            Issue.record("Expected to find a username and password")
+            return
+        }
+        #expect(user == "anotherlogin")
+        #expect(password == "anotherpassword")
     }
 }

--- a/Tests/ContainerRegistryTests/ImageReferenceTests.swift
+++ b/Tests/ContainerRegistryTests/ImageReferenceTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 @testable import ContainerRegistry
-import XCTest
+import Testing
 
 struct ReferenceTest {
     var reference: String
@@ -26,7 +26,7 @@ struct ReferenceTestCase {
     var expected: ImageReference?
 }
 
-class ReferenceTests: XCTestCase {
+struct ReferenceTests {
     let tests = [
         // A reference which does not contain a '/' is always interpreted as a repository name
         // in the default registry.
@@ -106,60 +106,59 @@ class ReferenceTests: XCTestCase {
         ),
     ]
 
-    func testReferences() throws {
+    @Test func testReferences() throws {
         for test in tests {
             let parsed = try! ImageReference(fromString: test.reference, defaultRegistry: "default")
-            XCTAssertEqual(
-                parsed,
-                test.expected,
+            #expect(
+                parsed == test.expected,
                 "\(String(reflecting: parsed)) is not equal to \(String(reflecting: test.expected))"
             )
         }
     }
 
-    func testLibraryReferences() throws {
+    @Test func testLibraryReferences() throws {
         // docker.io is a special case, as references such as "swift:slim" with no registry component are translated to "docker.io/library/swift:slim"
         // Verified against the behaviour of the docker CLI client
 
         // Fully-qualified name splits as usual
-        XCTAssertEqual(
-            try! ImageReference(fromString: "docker.io/library/swift:slim", defaultRegistry: "docker.io"),
-            ImageReference(registry: "index.docker.io", repository: "library/swift", reference: "slim")
+        #expect(
+            try! ImageReference(fromString: "docker.io/library/swift:slim", defaultRegistry: "docker.io")
+                == ImageReference(registry: "index.docker.io", repository: "library/swift", reference: "slim")
         )
 
         // A repository with no '/' part is assumed to be `library`
-        XCTAssertEqual(
-            try! ImageReference(fromString: "docker.io/swift:slim", defaultRegistry: "docker.io"),
-            ImageReference(registry: "index.docker.io", repository: "library/swift", reference: "slim")
+        #expect(
+            try! ImageReference(fromString: "docker.io/swift:slim", defaultRegistry: "docker.io")
+                == ImageReference(registry: "index.docker.io", repository: "library/swift", reference: "slim")
         )
 
         // Parsing with 'docker.io' as default registry is the same as the fully qualified case
-        XCTAssertEqual(
-            try! ImageReference(fromString: "library/swift:slim", defaultRegistry: "docker.io"),
-            ImageReference(registry: "index.docker.io", repository: "library/swift", reference: "slim")
+        #expect(
+            try! ImageReference(fromString: "library/swift:slim", defaultRegistry: "docker.io")
+                == ImageReference(registry: "index.docker.io", repository: "library/swift", reference: "slim")
         )
 
         // Bare image name with no registry or repository is interpreted as being in docker.io/library when default is docker.io
-        XCTAssertEqual(
-            try! ImageReference(fromString: "swift:slim", defaultRegistry: "docker.io"),
-            ImageReference(registry: "index.docker.io", repository: "library/swift", reference: "slim")
+        #expect(
+            try! ImageReference(fromString: "swift:slim", defaultRegistry: "docker.io")
+                == ImageReference(registry: "index.docker.io", repository: "library/swift", reference: "slim")
         )
 
         // The minimum reference to a library image.   No tag implies `latest`
-        XCTAssertEqual(
-            try! ImageReference(fromString: "swift", defaultRegistry: "docker.io"),
-            ImageReference(registry: "index.docker.io", repository: "library/swift", reference: "latest")
+        #expect(
+            try! ImageReference(fromString: "swift", defaultRegistry: "docker.io")
+                == ImageReference(registry: "index.docker.io", repository: "library/swift", reference: "latest")
         )
 
         // If the registry is not docker.io, the special case logic for `library` does not apply
-        XCTAssertEqual(
-            try! ImageReference(fromString: "localhost:5000/swift", defaultRegistry: "docker.io"),
-            ImageReference(registry: "localhost:5000", repository: "swift", reference: "latest")
+        #expect(
+            try! ImageReference(fromString: "localhost:5000/swift", defaultRegistry: "docker.io")
+                == ImageReference(registry: "localhost:5000", repository: "swift", reference: "latest")
         )
 
-        XCTAssertEqual(
-            try! ImageReference(fromString: "swift", defaultRegistry: "localhost:5000"),
-            ImageReference(registry: "localhost:5000", repository: "swift", reference: "latest")
+        #expect(
+            try! ImageReference(fromString: "swift", defaultRegistry: "localhost:5000")
+                == ImageReference(registry: "localhost:5000", repository: "swift", reference: "latest")
         )
     }
 }

--- a/Tests/containertoolTests/ZlibTests.swift
+++ b/Tests/containertoolTests/ZlibTests.swift
@@ -12,20 +12,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 @testable import containertool
 import Crypto
-import XCTest
+import Foundation
+import Testing
 
-class ZlibTests: XCTestCase, @unchecked Sendable {
-    // Check that compressing the same data on macOS and Linux produces the same output.
-    func testGzipHeader() async throws {
+// Check that compressing the same data on macOS and Linux produces the same output.
+struct ZlibTests {
+    @Test func testGzipHeader() async throws {
         let data = "test"
-
         let result = gzip([UInt8](data.utf8))
-        XCTAssertEqual(
-            "\(SHA256.hash(data: result))",
-            "SHA256 digest: 7dff8d09129482017247cb373e8138772e852a1a02f097d1440387055d2be69c"
+        #expect(
+            "\(SHA256.hash(data: result))"
+                == "SHA256 digest: 7dff8d09129482017247cb373e8138772e852a1a02f097d1440387055d2be69c"
         )
     }
 }

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -18,10 +18,6 @@ log() { printf -- "** %s\n" "$*" >&2; }
 error() { printf -- "** ERROR: %s\n" "$*" >&2; }
 fatal() { error "$@"; exit 1; }
 
-if [[ -n ${TOOLCHAINS+x} ]] ; then
-    fatal "Please unset the TOOLCHAINS environment variable.   The OSS Swift toolchain cannot run these tests because it does not include XCTest.framework."
-fi
-
 set -euo pipefail
 
 RUNTIME=${RUNTIME-"docker"}


### PR DESCRIPTION
Motivation
----------

swift-testing offers a more convenient way to write test cases.   For
instance, it makes table-driven tests much easier to write than XCTest.

Modifications
-------------

This commit rewrites the existing XCTest test cases to use swift-testing. It is a mechanical translation using the rules in:

   https://developer.apple.com/documentation/testing/migratingfromxctest

It does not try to adapt the style of the tests to `swift-testing`.

Result
------

The tests run using `swift-testing` with minimal changes. A future change will adapt them to make better use of the new framework's facilities.

One immediate improvement is that the `swift-testing` tests can be run with the OSS Swift toolchain on macOS.  `XCTests` cannot, because the framework is not included in the OSS toolchain.

Test Plan
---------

All tests continue to pass.