### PR TITLE
tests: Convert ReferenceTests to `swift-testing` parameterised tests

### DIFF
--- a/Sources/ContainerRegistry/ImageReference.swift
+++ b/Sources/ContainerRegistry/ImageReference.swift
@@ -48,7 +48,7 @@ func splitName(_ name: String) throws -> (String, String) {
 }
 
 /// ImageReference points to an image stored on a container registry
-public struct ImageReference: Equatable, CustomStringConvertible, CustomDebugStringConvertible {
+public struct ImageReference: Sendable, Equatable, CustomStringConvertible, CustomDebugStringConvertible {
     /// The registry which contains this image
     public var registry: String
     /// The repository which contains this image

--- a/Tests/ContainerRegistryTests/ImageReferenceTests.swift
+++ b/Tests/ContainerRegistryTests/ImageReferenceTests.swift
@@ -15,19 +15,13 @@
 @testable import ContainerRegistry
 import Testing
 
-struct ReferenceTest {
-    var reference: String
-    var registry: String
-    var repository: String
-}
-
-struct ReferenceTestCase {
+struct ReferenceTestCase: Sendable {
     var reference: String
     var expected: ImageReference?
 }
 
 struct ReferenceTests {
-    let tests = [
+    static let tests = [
         // A reference which does not contain a '/' is always interpreted as a repository name
         // in the default registry.
         ReferenceTestCase(
@@ -106,14 +100,12 @@ struct ReferenceTests {
         ),
     ]
 
-    @Test func testReferences() throws {
-        for test in tests {
-            let parsed = try! ImageReference(fromString: test.reference, defaultRegistry: "default")
-            #expect(
-                parsed == test.expected,
-                "\(String(reflecting: parsed)) is not equal to \(String(reflecting: test.expected))"
-            )
-        }
+    @Test(arguments: tests) func testReferences(test: ReferenceTestCase) throws {
+        let parsed = try! ImageReference(fromString: test.reference, defaultRegistry: "default")
+        #expect(
+            parsed == test.expected,
+            "\(String(reflecting: parsed)) is not equal to \(String(reflecting: test.expected))"
+        )
     }
 
     @Test func testLibraryReferences() throws {


### PR DESCRIPTION
Motivation
----------

`ImageReference.testReferences` tests is a table-driven test which iterates over a list of test cases.   Under `XCTest` it was implemented as a single test containing a loop, but with `swift-testing` the loop can be moved outside the test.   This makes it easier to see that multiple test cases are being run and to diagnose problems.

Modifications
-------------

`ImageReference.testReferences` now uses `@Test(arguments: ...)` to iterate over the existing test list.

Result
------

Test reports are more detailed. 

Test Plan
---------

All tests continue to pass.