### PR TITLE
container: Add application layer to the correct end of the layer stack

### DIFF
--- a/.github/workflows/interop_tests.yml
+++ b/.github/workflows/interop_tests.yml
@@ -1,0 +1,41 @@
+name: Interop tests
+
+on:
+    workflow_call:
+#        inputs:
+#            example:
+#                required: true
+#                type: string
+
+jobs:
+    layering-test:
+        name: Layering test
+        runs-on: ubuntu-latest
+        services:
+            registry:
+                image: registry:2
+                ports:
+                    - 5000:5000
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
+
+            - name: Mark the workspace as safe
+              # https://github.com/actions/checkout/issues/766
+              run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
+            # First layer: payload does not have to be an executable, it just has to have known contents
+            - name: Build first layer
+              run: |
+                  echo first > payload
+                  swift run containertool --repository localhost:5000/layering_test payload
+                  docker run --pull=always --rm --entrypoint=cat localhost:5000/layering_test payload | grep first
+
+            # Second layer: payload does not have to be an executable, it just has to have known contents.   It should replace the first layer.
+            - name: Build another layer, which should override 'payload' from the first layer
+              run: |
+                  echo second > payload
+                  swift run containertool --repository localhost:5000/layering_test payload --from localhost:5000/layering_test:latest
+                  docker run --pull=always --rm --entrypoint=cat localhost:5000/layering_test payload | grep second

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,6 +14,7 @@ jobs:
             license_header_check_project_name: "SwiftContainerPlugin"
             shell_check_container_image: "swift:6.0-noble"
 
+    # Unit tests for functions and modules
     unit-tests:
         name: Unit tests
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
@@ -24,6 +25,7 @@ jobs:
             linux_nightly_6_1_arguments_override: "--skip SmokeTests"
             linux_nightly_main_arguments_override: "--skip SmokeTests"
 
+    # Test functions and modules against an separate registry
     integration-tests:
         name: Integration tests
         runs-on: ubuntu-latest
@@ -51,6 +53,12 @@ jobs:
               run: |
                   swift test
 
+    # Test that outputs can be handled properly by other systems
+    interop-tests:
+        name: Interop tests
+        uses: ./.github/workflows/interop_tests.yml
+
+    # Full build-package-deploy-run cycles
     endtoend-tests:
         name: End to end tests
         uses: ./.github/workflows/endtoend_tests.yml

--- a/Sources/containertool/containertool.swift
+++ b/Sources/containertool/containertool.swift
@@ -161,12 +161,10 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
             config: inherited_config,
             rootfs: .init(
                 _type: "layers",
-                diff_ids: [
-                    // The diff_id is the digest of the _uncompressed_ layer archive.
-                    // It is used by the runtime, which might not store the layers in
-                    // the compressed form in which it received them from the registry.
-                    digest(of: tardiff)
-                ] + baseimage_config.rootfs.diff_ids
+                // The diff_id is the digest of the _uncompressed_ layer archive.
+                // It is used by the runtime, which might not store the layers in
+                // the compressed form in which it received them from the registry.
+                diff_ids: baseimage_config.rootfs.diff_ids + [digest(of: tardiff)]
             ),
             history: [.init(created: timestamp, created_by: "containertool")]
         )
@@ -184,7 +182,7 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
             schemaVersion: 2,
             mediaType: "application/vnd.oci.image.manifest.v1+json",
             config: config_blob,
-            layers: [application_layer] + baseimage_manifest.layers
+            layers: baseimage_manifest.layers + [application_layer]
         )
 
         // MARK: Upload base image


### PR DESCRIPTION
Motivation
----------

containertool currently adds the app layer to the beginning of the
layer stack array in the manifest. This results in the app layer
being the first to be unpacked, with the others stacked on top. We
can show this by adding a plain text file as the executable. If we
stack another layer on top with a file of the same name, it should
replace the underlying one but it does not:

    echo first > bar
    swift run containertool --repository localhost:5555/bar bar
    podman run --pull=always -it --rm --entrypoint=cat localhost:5555/bar:latest bar
    # prints: first

    echo second > bar
    swift run containertool --repository localhost:5555/bar bar --from localhost:5555/bar:latest
    podman run --pull=always -it --rm --entrypoint=cat localhost:5555/bar:latest bar
    # prints: first
    # should print: second

Currently containertool is only used to add the application binary
to the application layer. This bug will only cause a problem if the
base layer adds a binary at the same path, because this will override
the application.

This bug probably arose because the specification for the rootfs.diff_ids
field of the image configuration defines the layers as being "in
order from first to last", which could be read ambiguously:
https://github.com/opencontainers/image-spec/blob/main/config.md?plain=1#L220-L222

The specification for the manifest.layers field is much more explicit
about the ordering:
https://github.com/opencontainers/image-spec/blob/fbb4662eb53b80bd38f7597406cf1211317768f0/manifest.md?plain=1#L70-L71

Modifications
-------------

Append the application layer to layer stacks in the manifest and configuration blobs, instead of prepending.

Result
------

This with this change, the second build and container run in the
example above prints "second" as expected.

Test Plan
---------

This PR adds a new integration test which uses `containertool` to build two layers and check that they override each other correctly.

All existing tests continue to pass.

Fixes #57 