### PR TITLE
ci: Skip smoke tests for Swift 6.1

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,7 +21,7 @@ jobs:
             linux_5_9_enabled: false
             linux_5_10_enabled: false
             linux_6_0_arguments_override: "--skip SmokeTests"
-            linux_nightly_6_0_arguments_override: "--skip SmokeTests"
+            linux_nightly_6_1_arguments_override: "--skip SmokeTests"
             linux_nightly_main_arguments_override: "--skip SmokeTests"
 
     integration-tests:


### PR DESCRIPTION
Motivation
----------

The shared unit test workflow has been updated to run on Swift 6.1 nightlies: https://github.com/apple/swift-nio/pull/3076
A new `linux_nightly_6_1_arguments_override` parameter must be set to skip the smoke tests when running unit tests in CI.

Modifications
-------------

Define `linux_nightly_6_1_arguments_override` to ignore smoke tests.
Remove `linux_nightly_6_0_arguments_override` which is no longer used.

Result
------

Tests, including the daily test runs, will pass again.

Test Plan
---------

This fixes a test failure caused by the upstream shared workflows being changed.   All tests now pass again.