### PR TITLE
ci: Also skip smoke tests for Swift 6.1 on the main job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
             linux_5_9_enabled: false
             linux_5_10_enabled: false
             linux_6_0_arguments_override: "--skip SmokeTests"
-            linux_nightly_6_0_arguments_override: "--skip SmokeTests"
+            linux_nightly_6_1_arguments_override: "--skip SmokeTests"
             linux_nightly_main_arguments_override: "--skip SmokeTests"
 
     integration-tests:


### PR DESCRIPTION
The `main.yml` test also needs the changes from #53, but running the pull request tests does not show this.
