### PR TITLE
plugin, containertool: Remove unnecessarily broad Foundation imports

### DIFF
--- a/Plugins/ContainerImageBuilder/Pipe+lines.swift
+++ b/Plugins/ContainerImageBuilder/Pipe+lines.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
+import class Foundation.Pipe
 
 extension Pipe {
     var lines: AsyncThrowingStream<String, Error> {

--- a/Sources/ContainerRegistry/Blobs.swift
+++ b/Sources/ContainerRegistry/Blobs.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import HTTPTypes
-import Crypto
+import struct Crypto.SHA256
 
 /// Calculates the digest of a blob of data.
 /// - Parameter data: Blob of data to digest.

--- a/Sources/ContainerRegistry/ImageManifest+Digest.swift
+++ b/Sources/ContainerRegistry/ImageManifest+Digest.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import Crypto
+import struct Crypto.SHA256
 
 public extension ImageManifest {
     var digest: String {

--- a/Sources/Tar/tar.swift
+++ b/Sources/Tar/tar.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
+import struct Foundation.Data
 
 // This file defines a basic tar writer which produces POSIX tar files.
 // This avoids the need to depend on a system-provided tar binary.

--- a/Sources/containertool/Extensions/RegistryClient+Layers.swift
+++ b/Sources/containertool/Extensions/RegistryClient+Layers.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
+import struct Foundation.Data
 import ContainerRegistry
 
 extension RegistryClient {

--- a/Tests/ContainerRegistryTests/SmokeTests.swift
+++ b/Tests/ContainerRegistryTests/SmokeTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
+import class Foundation.ProcessInfo
 import ContainerRegistry
 import Testing
 

--- a/Tests/TarTests/TarUnitTests.swift
+++ b/Tests/TarTests/TarUnitTests.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Testing
 
 @testable import Tar

--- a/Tests/containertoolTests/ZlibTests.swift
+++ b/Tests/containertoolTests/ZlibTests.swift
@@ -14,7 +14,6 @@
 
 @testable import containertool
 import Crypto
-import Foundation
 import Testing
 
 // Check that compressing the same data on macOS and Linux produces the same output.

--- a/Tests/containertoolTests/ZlibTests.swift
+++ b/Tests/containertoolTests/ZlibTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 @testable import containertool
-import Crypto
+import struct Crypto.SHA256
 import Testing
 
 // Check that compressing the same data on macOS and Linux produces the same output.


### PR DESCRIPTION
Motivation
----------

In many places we import a whole module but only use one or two structs or classes.   In these cases, importing just the parts we need makes dependencies clearer.

Modifications
-------------

* Where only one definition is used, constrain the import statement to only that definition.
* Remove a couple of Foundation imports which were completely unused.

Result
------

No functional change.  Dependencies are clearer.

Test Plan
---------

Tests continue to pass.