### PR TITLE
tests: Build the layering test images on scratch to avoid pulling swift:slim

### DIFF
--- a/.github/workflows/interop_tests.yml
+++ b/.github/workflows/interop_tests.yml
@@ -29,13 +29,17 @@ jobs:
             # First layer: payload does not have to be an executable, it just has to have known contents
             - name: Build first layer
               run: |
-                  echo first > payload
-                  swift run containertool --repository localhost:5000/layering_test payload
-                  docker run --pull=always --rm --entrypoint=cat localhost:5000/layering_test payload | grep first
+                  echo first layer > payload
+                  swift run containertool --repository localhost:5000/layering_test payload --from scratch
+                  docker create --name first --pull always localhost:5000/layering_test
+                  docker cp first:/payload first.payload
+                  grep first first.payload
 
             # Second layer: payload does not have to be an executable, it just has to have known contents.   It should replace the first layer.
             - name: Build another layer, which should override 'payload' from the first layer
               run: |
-                  echo second > payload
+                  echo second layer > payload
                   swift run containertool --repository localhost:5000/layering_test payload --from localhost:5000/layering_test:latest
-                  docker run --pull=always --rm --entrypoint=cat localhost:5000/layering_test payload | grep second
+                  docker create --name second --pull always localhost:5000/layering_test
+                  docker cp second:/payload second.payload
+                  grep second second.payload


### PR DESCRIPTION
Motivation
----------

The layering tests sometimes fail with 400 errors from the registry.   This error could be caused by pulling the underlying base image from Docker Hub, although the logs do not give enough information to be certain.

We don't need to run the container image in order to check that the payload file is being layered correctly.    This would avoid the need to pull `swift:slim`, reducing the risk of external systems causing test failures.

Modifications
-------------

Build the test image on scratch.
Instead of running the container and using `cat` to check the contents of `/payload`, create a container from the image and copy `/payload` out, without starting the container.
 
Result
------

The layering tests should be less susceptible to failures caused by external systems.

Test Plan
---------

All tests continue to pass.