### PR TITLE
Package.swift, containertool: Make multi-line definitions clearer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,9 @@ let package = Package(
         .executableTarget(
             name: "containertool",
             dependencies: [
-                .target(name: "ContainerRegistry"), .target(name: "VendorCNIOExtrasZlib"), .target(name: "Tar"),
+                .target(name: "ContainerRegistry"),
+                .target(name: "VendorCNIOExtrasZlib"),
+                .target(name: "Tar"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
             swiftSettings: [.swiftLanguageMode(.v5)]
@@ -51,7 +53,8 @@ let package = Package(
             dependencies: [],
             path: "Vendor/github.com/apple/swift-nio-extras/Sources/CNIOExtrasZlib",
             linkerSettings: [.linkedLibrary("z")]
-        ), .target(name: "Tar"),
+        ),
+        .target(name: "Tar"),
         .target(
             // Vendored from https://github.com/apple/swift-package-manager with modifications
             name: "Basics",
@@ -86,7 +89,8 @@ let package = Package(
             name: "ContainerRegistryTests",
             dependencies: [.target(name: "ContainerRegistry")],
             resources: [.process("Resources")]
-        ), .testTarget(name: "containertoolTests", dependencies: [.target(name: "containertool")]),
+        ),
+        .testTarget(name: "containertoolTests", dependencies: [.target(name: "containertool")]),
         .testTarget(name: "TarTests", dependencies: [.target(name: "Tar")]),
     ],
     swiftLanguageModes: [.v6]

--- a/Sources/containertool/containertool.swift
+++ b/Sources/containertool/containertool.swift
@@ -28,36 +28,45 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
         abstract: "Build and upload a container image"
     )
 
-    @Option(help: "Default registry for references which do not specify a registry") private var defaultRegistry:
-        String = ProcessInfo.processInfo.environment["CONTAINERTOOL_DEFAULT_REGISTRY"] ?? "docker.io"
+    @Option(help: "Default registry for references which do not specify a registry")
+    private var defaultRegistry: String =
+        ProcessInfo.processInfo.environment["CONTAINERTOOL_DEFAULT_REGISTRY"] ?? "docker.io"
 
-    @Option(help: "Repository path") private var repository: String
+    @Option(help: "Repository path")
+    private var repository: String
 
-    @Argument(help: "Executable to package") private var executable: String
+    @Argument(help: "Executable to package")
+    private var executable: String
 
-    @Option(help: "Username") private var username: String?
+    @Option(help: "Username")
+    private var username: String?
 
-    @Option(help: "Password") private var password: String?
+    @Option(help: "Password")
+    private var password: String?
 
-    @Flag(name: .shortAndLong, help: "Verbose output") private var verbose: Bool = false
+    @Flag(name: .shortAndLong, help: "Verbose output")
+    private var verbose: Bool = false
 
-    @Option(help: "Connect to the container registry using plaintext HTTP") var allowInsecureHttp: AllowHTTP?
+    @Option(help: "Connect to the container registry using plaintext HTTP")
+    var allowInsecureHttp: AllowHTTP?
 
-    @Option(help: "CPU architecture") private var architecture: String =
-        ProcessInfo.processInfo.environment["CONTAINERTOOL_ARCHITECTURE"] ?? "amd64"
+    @Option(help: "CPU architecture")
+    private var architecture: String = ProcessInfo.processInfo.environment["CONTAINERTOOL_ARCHITECTURE"] ?? "amd64"
 
-    @Option(help: "Base image reference") private var from: String =
-        ProcessInfo.processInfo.environment["CONTAINERTOOL_BASE_IMAGE"] ?? "swift:slim"
+    @Option(help: "Base image reference")
+    private var from: String = ProcessInfo.processInfo.environment["CONTAINERTOOL_BASE_IMAGE"] ?? "swift:slim"
 
-    @Option(help: "Operating system") private var os: String =
-        ProcessInfo.processInfo.environment["CONTAINERTOOL_OS"] ?? "linux"
+    @Option(help: "Operating system")
+    private var os: String = ProcessInfo.processInfo.environment["CONTAINERTOOL_OS"] ?? "linux"
 
-    @Option(help: "Tag for this manifest") private var tag: String?
+    @Option(help: "Tag for this manifest")
+    private var tag: String?
 
     @Flag(inversion: .prefixedEnableDisable, exclusivity: .exclusive, help: "Load credentials from a netrc file")
     private var netrc: Bool = true
 
-    @Option(help: "Specify the netrc file path") private var netrcFile: String?
+    @Option(help: "Specify the netrc file path")
+    private var netrcFile: String?
 
     func run() async throws {
         let baseimage = try ImageReference(fromString: from, defaultRegistry: defaultRegistry)


### PR DESCRIPTION
Motivation
----------

Commit 9a3e7af92e3093f41deb8c83ed9fd25e59a3de90 configured `swift-format` to retain existing line breaks to make complex test case definitions easier to read.   

Modifications
-------------

This commit reformats complex definitions in `Package.swift` and `containertool` to make more readable.

Result
------

`Package.swift` and `containertool` will be easier to read and modify.   Diffs will be easier to read because partial line changes will be less likely.
No functional change.

Test Plan
---------

Tests continue to pass.