### PR TITLE
Readme, Examples: Update minimum plugin version in examples

### DIFF
--- a/Examples/HelloWorldHummingbird/Package.swift
+++ b/Examples/HelloWorldHummingbird/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.1.0"),
-        .package(url: "https://github.com/apple/swift-container-plugin", from: "0.2.0"),
+        .package(url: "https://github.com/apple/swift-container-plugin", from: "0.4.0"),
     ],
     targets: [
         .executableTarget(name: "hello-world", dependencies: [.product(name: "Hummingbird", package: "hummingbird")])

--- a/Examples/HelloWorldVapor/Package.swift
+++ b/Examples/HelloWorldVapor/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     platforms: [.macOS(.v13)],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor", .upToNextMajor(from: "4.102.0")),
-        .package(url: "https://github.com/apple/swift-container-plugin", from: "0.2.0"),
+        .package(url: "https://github.com/apple/swift-container-plugin", from: "0.4.0"),
     ],
     targets: [.executableTarget(name: "hello-world", dependencies: [.product(name: "Vapor", package: "vapor")])]
 )

--- a/Sources/ContainerImageBuilderPluginDocumentation/Documentation.docc/ContainerImageBuilderPlugin.md
+++ b/Sources/ContainerImageBuilderPluginDocumentation/Documentation.docc/ContainerImageBuilderPlugin.md
@@ -41,14 +41,14 @@ swift-6.0.1-RELEASE_static-linux-0.0.1
 Swift Container Plugin is distributed as a Swift Package Manager package.   Use the `swift package` command to add it to your project:
 
 ```shell
-swift package add-dependency https://github.com/apple/swift-container-plugin --from 0.1.0
+swift package add-dependency https://github.com/apple/swift-container-plugin --from 0.4.0
 ```
 
 Alternatively, append the following lines to `Package.swift`:
 
 ```swift
 package.dependencies += [
-    .package(url: "https://github.com/apple/swift-container-plugin", from: "0.1.0"),
+    .package(url: "https://github.com/apple/swift-container-plugin", from: "0.4.0"),
 ]
 ```
 


### PR DESCRIPTION
Motivation
----------

Examples showing how to use the plugin should refer to the latest version.   SwiftPM will choose the most recent version automatically, but it can be distracting for new users if examples refer to old versions of the plugin. 

Modifications
-------------

Update README and `Package.swift` files in `Examples` to use release 0.4.0.

Result
------

Examples are up to date.

Test Plan
---------

Existing tests continue to pass.