### PR TITLE
tar: Refactor tar writer, add a struct to represent tar headers

### DIFF
--- a/Tests/TarTests/TarUnitTests.swift
+++ b/Tests/TarTests/TarUnitTests.swift
@@ -101,12 +101,12 @@ let trailerLen = 2 * blocksize
 
     @Test func testEmptyName() async throws {
         #expect(throws: TarError.invalidName("")) {
-            let _ = try tarHeader(filesize: 0, filename: "")
+            let _ = try TarHeader(name: "", size: 0)
         }
     }
 
     @Test func testSingleEmptyFile() async throws {
-        let hdr = try tarHeader(filesize: 0, filename: "filename")
+        let hdr = try TarHeader(name: "filename", size: 0).bytes
         #expect(hdr.count == 512)
         #expect(
             hdr == [
@@ -131,7 +131,7 @@ let trailerLen = 2 * blocksize
     }
 
     @Test func testSingle1kBFile() async throws {
-        let hdr = try tarHeader(filesize: 1024, filename: "filename")
+        let hdr = try TarHeader(name: "filename", size: 1024).bytes
         #expect(hdr.count == 512)
         #expect(
             hdr == [


### PR DESCRIPTION
Motivation
----------

The tar writer is able to write a single file into a tar archive.   This is enough to build a container image around a single executable, but adding resource bundles (issue #48) requires the ability to write multiple files, directories and possibly symlinks into the archive.   This commit begins to refactor the tar writer to support this.   A future commit will add interoperability testing to ensure that more complex archives can be unpacked correctly.

Modifications
-------------

* Add a TarHeader struct representing a standard tar archive member
* Convert type flags to an enum
* Wrap fields in a namespacing enum

Result
------

No functional change.   Tar writer is more modular, easier to test and extend.

Test Plan
---------

Existing tests continue to pass.