### PR TITLE
ci: Use a shared definition of integration tests in pull request and main jobs

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,36 @@
+name: Integration tests
+
+on:
+    workflow_call:
+
+jobs:
+    integration-tests:
+        name: Integration tests
+        runs-on: ubuntu-latest
+        services:
+            registry:
+                image: registry:2
+                ports:
+                    - 5000:5000
+        container:
+            image: swift:6.0-noble
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
+
+            - name: Mark the workspace as safe
+              # https://github.com/actions/checkout/issues/766
+              run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
+            - name: Install bsdtar
+              run: |
+                which bsdtar || (apt-get -q update && apt-get -yq install libarchive-tools)
+
+            - name: Run test job
+              env:
+                  REGISTRY_HOST: registry
+                  REGISTRY_PORT: 5000
+              run: |
+                  swift test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,30 +20,7 @@ jobs:
 
     integration-tests:
         name: Integration tests
-        runs-on: ubuntu-latest
-        services:
-            registry:
-                image: registry:2
-                ports:
-                    - 5000:5000
-        container:
-            image: swift:6.0-noble
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4
-              with:
-                  persist-credentials: false
-
-            - name: Mark the workspace as safe
-              # https://github.com/actions/checkout/issues/766
-              run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
-
-            - name: Run test job
-              env:
-                  REGISTRY_HOST: registry
-                  REGISTRY_PORT: 5000
-              run: |
-                  swift test
+        uses: ./.github/workflows/integration_tests.yml
 
     endtoend-tests:
         name: End to end tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,37 +25,10 @@ jobs:
             linux_nightly_6_1_arguments_override: "--skip SmokeTests --skip TarInteropTests"
             linux_nightly_main_arguments_override: "--skip SmokeTests --skip TarInteropTests"
 
-    # Test functions and modules against an separate registry
+    # Test functions and modules against a separate registry
     integration-tests:
         name: Integration tests
-        runs-on: ubuntu-latest
-        services:
-            registry:
-                image: registry:2
-                ports:
-                    - 5000:5000
-        container:
-            image: swift:6.0-noble
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4
-              with:
-                  persist-credentials: false
-
-            - name: Mark the workspace as safe
-              # https://github.com/actions/checkout/issues/766
-              run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
-
-            - name: Install bsdtar
-              run: |
-                which bsdtar || (apt-get -q update && apt-get -yq install libarchive-tools)
-
-            - name: Run test job
-              env:
-                  REGISTRY_HOST: registry
-                  REGISTRY_PORT: 5000
-              run: |
-                  swift test
+        uses: ./.github/workflows/integration_tests.yml
 
     # Test that outputs can be handled properly by other systems
     interop-tests:


### PR DESCRIPTION
Motivation
----------

The definition of the integration test job was duplicated in `main.yml` and `pull_request.yml`.   When changes were made in one but not the other, the pull request CI job passed but the main CI job later failed after the pull request had been merged.

Modifications
-------------

* The integration test job has been moved to a shared file which `main.yml` and `pull_request.yml` can both include.

Result
------

If the pull request job succeeds, the main job should also succeed.

Test Plan
---------

Tests on main branch pass again.