### PR TITLE
ci: Skip Tar interop tests in main unit test job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,9 @@ jobs:
         with:
             linux_5_9_enabled: false
             linux_5_10_enabled: false
-            linux_6_0_arguments_override: "--skip SmokeTests"
-            linux_nightly_6_1_arguments_override: "--skip SmokeTests"
-            linux_nightly_main_arguments_override: "--skip SmokeTests"
+            linux_6_0_arguments_override: "--skip SmokeTests --skip TarInteropTests"
+            linux_nightly_6_1_arguments_override: "--skip SmokeTests --skip TarInteropTests"
+            linux_nightly_main_arguments_override: "--skip SmokeTests --skip TarInteropTests"
 
     integration-tests:
         name: Integration tests


### PR DESCRIPTION
Motivation
----------

The main unit test job needs to match the pull_request unit test job.   Both jobs depend on `swift-nio`'s shared unit test job, so it's unclear whether this can be abstracted further.

Modifications
-------------

* Update the `--skip` parameters in `main.yml` to match `pull_request.yml`

Result
------

The results of `main` unit test job should match those of the `pull_request` unit test job.

Test Plan
---------

Unit tests run on the main branch should pass again.