### PR TITLE
containertool: Move ELF architecture translation extension to Extensions

### DIFF
--- a/Sources/containertool/Extensions/ELF+containerArchitecture.swift
+++ b/Sources/containertool/Extensions/ELF+containerArchitecture.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftContainerPlugin open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftContainerPlugin project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftContainerPlugin project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+extension ELF.ISA {
+    /// Converts the ELF architecture to the GOARCH string representation understood by the container runtime.
+    /// Unsupported architectures are mapped to nil.
+    var containerArchitecture: String? {
+        switch self {
+        case .x86_64: "amd64"
+        case .aarch64: "arm64"
+        default: nil
+        }
+    }
+}

--- a/Sources/containertool/containertool.swift
+++ b/Sources/containertool/containertool.swift
@@ -237,13 +237,3 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
         print(destination_image)
     }
 }
-
-extension ELF.ISA {
-    var containerArchitecture: String? {
-        switch self {
-        case .x86_64: "amd64"
-        case .aarch64: "arm64"
-        default: nil
-        }
-    }
-}


### PR DESCRIPTION
Motivation
----------

All extensions defined in `containertool` should be in the `Extensions` subdirectory.

Modifications
-------------

Move `ELF.containerArchitecture` extension to `Extensions`.

Result
------

All `containertool` extensions can be found in one place.

Test Plan
---------

Tests continue to pass.