### PR TITLE
tar: Add support for archiving directories

### DIFF
--- a/Sources/Tar/tar.swift
+++ b/Sources/Tar/tar.swift
@@ -22,6 +22,18 @@ import struct Foundation.Data
 // relatively straightforward;  reading an arbitrary tar file is more
 // complicated because the reader must be prepared to handle all variants.
 
+// Tar archives consist of 512-byte blocks, either containing member headers
+// or file data.   Blocks shorter than 512 bytes are padded with zeros.
+let blockSize = 512
+
+/// Returns the number of padding bytes to be appended to a file.
+/// Each file in a tar archive must be padded to a multiple of the 512 byte block size.
+/// - Parameter len: The length of the archive member.
+/// - Returns: The number of zero bytes to append as padding.
+func padding(_ len: Int) -> Int {
+    (blockSize - len % blockSize) % blockSize
+}
+
 enum TarError: Error, Equatable {
     case invalidName(String)
 }
@@ -134,7 +146,7 @@ func checksum(header: [UInt8]) -> Int {
     // The checksum calculation can't overflow (maximum possible value 776) so we can use
     // unchecked arithmetic.
 
-    precondition(header.count == 512)
+    precondition(header.count == blockSize)
     return header.reduce(0) { $0 &+ Int($1) }
 }
 
@@ -182,7 +194,7 @@ public enum MemberType: String {
 
 // maybe limited string, octal6 and octal11 should be separate types
 
-/// Represents a single tar archive member
+/// Represents a single tar archive member header
 public struct TarHeader {
     /// Member file name when unpacked
     var name: String
@@ -232,7 +244,7 @@ public struct TarHeader {
     /// Filename prefix - prepended to name
     var prefix: String = ""
 
-    init(
+    public init(
         name: String,
         mode: Int = 0o555,
         uid: Int = 0,
@@ -273,10 +285,7 @@ public struct TarHeader {
 }
 
 extension TarHeader {
-    /// Creates a tar header for a single file
-    /// - Parameters:
-    ///   - hdr: The header structure of the file
-    /// - Returns: A tar header representing the file
+    /// The serialized byte representation of the header.
     var bytes: [UInt8] {
         // A file entry consists of a file header followed by the
         // contents of the file. The header includes information such as
@@ -285,7 +294,7 @@ extension TarHeader {
         //
         // The file data is padded with nulls to a multiple of 512 bytes.
 
-        var bytes = [UInt8](repeating: 0, count: 512)
+        var bytes = [UInt8](repeating: 0, count: blockSize)
 
         // Construct a POSIX ustar header for the file
         bytes.writeString(self.name, inField: Field.name, withTermination: .null)
@@ -312,16 +321,6 @@ extension TarHeader {
     }
 }
 
-let blockSize = 512
-
-/// Returns the number of padding bytes to be appended to a file.
-/// Each file in a tar archive must be padded to a multiple of the 512 byte block size.
-/// - Parameter len: The length of the archive member.
-/// - Returns: The number of zero bytes to append as padding.
-func padding(_ len: Int) -> Int {
-    (blockSize - len % blockSize) % blockSize
-}
-
 /// Creates a tar archive containing a single file
 /// - Parameters:
 ///   - bytes: The file's body data
@@ -339,7 +338,7 @@ public func tar(_ bytes: [UInt8], filename: String = "app") throws -> [UInt8] {
     archive.append(contentsOf: padding)
 
     // Append the end of file marker
-    let marker = [UInt8](repeating: 0, count: 2 * 512)
+    let marker = [UInt8](repeating: 0, count: 2 * blockSize)
     archive.append(contentsOf: marker)
     return archive
 }
@@ -352,4 +351,109 @@ public func tar(_ bytes: [UInt8], filename: String = "app") throws -> [UInt8] {
 /// - Throws: If the filename is invalid
 public func tar(_ data: Data, filename: String) throws -> [UInt8] {
     try tar([UInt8](data), filename: filename)
+}
+
+/// Represents a tar archive
+public struct Archive {
+    /// The files, directories and other members of the archive
+    var members: [ArchiveMember]
+
+    /// Creates an empty Archive
+    public init() {
+        members = []
+    }
+
+    /// Appends a member to the archive
+    /// Parameters:
+    /// - member: The member to append
+    public mutating func append(_ member: ArchiveMember) {
+        self.members.append(member)
+    }
+
+    /// Returns a new archive made by appending a member to the receiver
+    /// Parameters:
+    /// - member: The member to append
+    /// Returns: A new archive made by appending `member` to the receiver.
+    public func appending(_ member: ArchiveMember) -> Self {
+        var ret = self
+        ret.members += [member]
+        return ret
+    }
+
+    /// The serialized byte representation of the archive, including padding and end-of-archive marker.
+    public var bytes: [UInt8] {
+        var ret: [UInt8] = []
+        for member in members {
+            ret.append(contentsOf: member.bytes)
+        }
+
+        // Append the end of file marker
+        let marker = [UInt8](repeating: 0, count: 2 * blockSize)
+        ret.append(contentsOf: marker)
+
+        return ret
+    }
+}
+
+/// Represents a member of a tar archive
+public struct ArchiveMember {
+    /// Member header containing metadata about the member
+    var header: TarHeader
+
+    /// File content
+    var contents: [UInt8]
+
+    /// Creates a new ArchiveMember
+    /// Parameters:
+    /// - header: Member header containing metadata about the member
+    /// - data: File content
+    public init(
+        header: TarHeader,
+        data: [UInt8] = []
+    ) {
+        self.header = header
+        self.contents = data
+    }
+
+    /// The serialized byte representation of the member, including padding.
+    public var bytes: [UInt8] {
+        let padding = [UInt8](repeating: 0, count: padding(contents.count))
+        return header.bytes + self.contents + padding
+    }
+}
+
+extension Archive {
+    /// Adds a new file member at the end of the archive
+    /// parameters:
+    /// - name: File name
+    /// - prefix: Path prefix
+    /// - data: File contents
+    public mutating func appendFile(name: String, prefix: String = "", data: [UInt8]) throws {
+        try append(.init(header: .init(name: name, size: data.count, prefix: prefix), data: data))
+    }
+
+    /// Adds a new file member at the end of the archive
+    /// parameters:
+    /// - name: File name
+    /// - prefix: Path prefix
+    /// - data: File contents
+    public func appendingFile(name: String, prefix: String = "", data: [UInt8]) throws -> Self {
+        try appending(.init(header: .init(name: name, size: data.count, prefix: prefix), data: data))
+    }
+
+    /// Adds a new directory member at the end of the archive
+    /// parameters:
+    /// - name: Directory name
+    /// - prefix: Path prefix
+    public mutating func appendDirectory(name: String, prefix: String = "") throws {
+        try append(.init(header: .init(name: name, typeflag: .DIRTYPE, prefix: prefix)))
+    }
+
+    /// Adds a new directory member at the end of the archive
+    /// parameters:
+    /// - name: Directory name
+    /// - prefix: Path prefix
+    public func appendingDirectory(name: String, prefix: String = "") throws -> Self {
+        try self.appending(.init(header: .init(name: name, typeflag: .DIRTYPE, prefix: prefix)))
+    }
 }

--- a/Tests/TarTests/TarInteropTests.swift
+++ b/Tests/TarTests/TarInteropTests.swift
@@ -12,7 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
+import class Foundation.Pipe
+import class Foundation.Process
+
 import Testing
 @testable import Tar
 
@@ -43,7 +45,7 @@ import Testing
     @Test func testSingle4BFile() async throws {
         let data = "test"
         let result = try tar([UInt8](data.utf8), filename: "filename")
-        #expect(result.count == headerLen + blocksize + trailerLen)
+        #expect(result.count == headerSize + blockSize + trailerSize)
 
         let output = try await tarListContents(result)
         #expect(output == "-r-xr-xr-x  0 0      0           4 Jan  1  1970 filename")
@@ -60,7 +62,7 @@ import Testing
 
         let data = ""
         let result = try tar([UInt8](data.utf8), filename: "filename")
-        #expect(result.count == headerLen + trailerLen)
+        #expect(result.count == headerSize + trailerSize)
 
         let output = try await tarListContents(result)
         #expect(output == "-r-xr-xr-x  0 0      0           0 Jan  1  1970 filename")
@@ -72,7 +74,7 @@ import Testing
         hdr.append(contentsOf: try TarHeader(name: "filename1", size: 0).bytes)
 
         // No file data, no padding, no end of file marker
-        #expect(hdr.count == headerLen)
+        #expect(hdr.count == headerSize)
 
         // bsdtar tolerates the lack of end of file marker
         let output = try await tarListContents(hdr)

--- a/Tests/TarTests/TarUnitTests.swift
+++ b/Tests/TarTests/TarUnitTests.swift
@@ -16,9 +16,11 @@ import Testing
 
 @testable import Tar
 
-let blocksize = 512
-let headerLen = blocksize
-let trailerLen = 2 * blocksize
+let blockSize = 512
+let headerSize = blockSize
+let trailerSize = 2 * blockSize
+
+let trailer = [UInt8](repeating: 0, count: trailerSize)
 
 @Suite struct TarUnitTests {
     @Test(arguments: [
@@ -153,5 +155,330 @@ let trailerLen = 2 * blocksize
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             ]
         )
+    }
+
+    let emptyFile: [UInt8] = [
+        // name: 100 bytes
+        101, 109, 112, 116, 121, 102, 105, 108, 101, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0,
+
+        // mode: 8 bytes
+        48, 48, 48, 53, 53, 53, 32, 0,
+
+        // uid: 8 bytes
+        48, 48, 48, 48, 48, 48, 32, 0,
+
+        // gid: 8 bytes
+        48, 48, 48, 48, 48, 48, 32, 0,
+
+        // size: 12 bytes
+        48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 32,
+
+        // mtime: 12 bytes
+        48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 32,
+
+        // chksum: 8 bytes
+        48, 49, 49, 48, 55, 53, 0, 32,
+
+        // typeflag: 1 byte
+        48,
+
+        // linkname: 100 bytes
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0,
+
+        // magic: 6 bytes
+        117, 115, 116, 97, 114, 0,
+
+        // version: 2 bytes
+        48, 48,
+
+        // uname: 32 bytes
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+
+        // gname: 32 bytes
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+
+        // devmajor: 8 bytes
+        48, 48, 48, 48, 48, 48, 32, 0,
+        // devminor: 8 bytes
+        48, 48, 48, 48, 48, 48, 32, 0,
+
+        // prefix: 155 bytes
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+
+        // padding: 12 bytes
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]
+
+    @Test func testAppendingEmptyFile() async throws {
+        let archive = try Archive().appendingFile(name: "emptyfile", data: []).bytes
+
+        // Expecting: member header, no file content, 2-block end of archive marker
+        #expect(archive.count == headerSize + trailerSize)
+        #expect(archive == emptyFile + trailer)
+    }
+
+    let helloFile: [UInt8] =
+        [
+            // name: 100 bytes
+            104, 101, 108, 108, 111, 102, 105, 108, 101, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0,
+
+            // mode: 8 bytes
+            48, 48, 48, 53, 53, 53, 32, 0,
+
+            // uid: 8 bytes
+            48, 48, 48, 48, 48, 48, 32, 0,
+
+            // gid: 8 bytes
+            48, 48, 48, 48, 48, 48, 32, 0,
+
+            // size: 12 bytes
+            48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 53, 32,
+
+            // mtime: 12 bytes
+            48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 32,
+
+            // chksum: 8 bytes
+            48, 49, 49, 48, 52, 55, 0, 32,
+
+            // typeflag: 1 byte
+            48,
+
+            // linkname: 100 bytes
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0,
+
+            // magic: 6 bytes
+            117, 115, 116, 97, 114, 0,
+
+            // version: 2 bytes
+            48, 48,
+
+            // uname: 32 bytes
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+
+            // gname: 32 bytes
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+
+            // devmajor: 8 bytes
+            48, 48, 48, 48, 48, 48, 32, 0,
+            // devminor: 8 bytes
+            48, 48, 48, 48, 48, 48, 32, 0,
+
+            // prefix: 155 bytes
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+
+            // padding: 12 bytes
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ] + [
+            // file contents: "hello", padded to 512 bytes
+            104, 101, 108, 108, 111, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ]
+
+    @Test func testAppendFile() async throws {
+        var archive = Archive()
+        try archive.appendFile(name: "hellofile", data: [UInt8]("hello".utf8))
+        let output = archive.bytes
+
+        // Expecting: member header, file content, 2-block end of archive marker
+        #expect(output.count == headerSize + blockSize + trailerSize)
+        #expect(output == helloFile + trailer)
+    }
+
+    @Test func testAppendingFile() async throws {
+        let archive = try Archive().appendingFile(name: "hellofile", data: [UInt8]("hello".utf8)).bytes
+
+        // Expecting: member header, file content, 2-block end of archive marker
+        #expect(archive.count == headerSize + blockSize + trailerSize)
+        #expect(archive == helloFile + trailer)
+    }
+
+    let directoryWithPrefix: [UInt8] = [
+        // name: 100 bytes
+        100, 105, 114, 101, 99, 116, 111, 114, 121, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0,
+
+        // mode: 8 bytes
+        48, 48, 48, 53, 53, 53, 32, 0,
+
+        // uid: 8 bytes
+        48, 48, 48, 48, 48, 48, 32, 0,
+
+        // gid: 8 bytes
+        48, 48, 48, 48, 48, 48, 32, 0,
+
+        // size: 12 bytes
+        48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 32,
+
+        // mtime: 12 bytes
+        48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 32,
+
+        // chksum: 8 bytes
+        48, 49, 50, 51, 50, 54, 0, 32,
+
+        // typeflag: 1 byte
+        53,
+
+        // linkname: 100 bytes
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0,
+
+        // magic: 6 bytes
+        117, 115, 116, 97, 114, 0,
+
+        // version: 2 bytes
+        48, 48,
+
+        // uname: 32 bytes
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+
+        // gname: 32 bytes
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+
+        // devmajor: 8 bytes
+        48, 48, 48, 48, 48, 48, 32, 0,
+        // devminor: 8 bytes
+        48, 48, 48, 48, 48, 48, 32, 0,
+
+        // prefix: 155 bytes
+        112, 114, 101, 102, 105, 120, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+
+        // padding: 12 bytes
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]
+
+    @Test func testAppendDirectory() async throws {
+        var archive = Archive()
+        try archive.appendDirectory(name: "directory", prefix: "prefix")
+        let output = archive.bytes
+
+        // Expecting: member header, no content, 2-block end of archive marker
+        #expect(output.count == headerSize + trailerSize)
+        #expect(output == directoryWithPrefix + trailer)
+    }
+
+    @Test func testAppendingDirectory() async throws {
+        let archive = try Archive().appendingDirectory(name: "directory", prefix: "prefix").bytes
+
+        // Expecting: member header, no content, 2-block end of archive marker
+        #expect(archive.count == headerSize + trailerSize)
+        #expect(archive == directoryWithPrefix + trailer)
+    }
+
+    @Test func testAppendFilesAndDirectories() async throws {
+        var archive = Archive()
+        try archive.appendFile(name: "hellofile", data: [UInt8]("hello".utf8))
+        try archive.appendFile(name: "emptyfile", data: [UInt8]())
+        try archive.appendDirectory(name: "directory", prefix: "prefix")
+
+        let output = archive.bytes
+
+        // Expecting: file member header, file content, file member header, no file content,
+        //     directory member header, 2-block end of archive marker
+        #expect(output.count == headerSize + blockSize + headerSize + headerSize + trailerSize)
+        #expect(output == helloFile + emptyFile + directoryWithPrefix + trailer)
+    }
+
+    @Test func testAppendingFilesAndDirectories() async throws {
+        let archive = try Archive()
+            .appendingFile(name: "hellofile", data: [UInt8]("hello".utf8))
+            .appendingFile(name: "emptyfile", data: [UInt8]())
+            .appendingDirectory(name: "directory", prefix: "prefix")
+            .bytes
+
+        // Expecting: file member header, file content, file member header, no file content,
+        //     directory member header, 2-block end of archive marker
+        #expect(archive.count == headerSize + blockSize + headerSize + headerSize + trailerSize)
+        #expect(archive == helloFile + emptyFile + directoryWithPrefix + trailer)
     }
 }


### PR DESCRIPTION
Motivation
----------

The tar writer currently provides helper functions which can create tar archives containing single executable files.   In order to include resource bundles in container images (#48) the tar writer must be able create archives containing multiple files and directories.

Modifications
-------------

* A new `Archive` type representing a tar archive allows multiple files to be added before being written out as an array of bytes.
* Helper functions allow files and directories to be added to the archive.

Result
------

The tar writer is able to create archives containing files and directories.

Test Plan
---------

New tests exercise creating archives containing multiple members, including directories.