### PR TITLE
plugin: handle chunks of output correctly

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -34,3 +34,25 @@ jobs:
                   REGISTRY_PORT: 5000
               run: |
                   swift test
+
+    plugin-streaming-output-test:
+        name: Plugin streaming output test
+        runs-on: ubuntu-latest
+        services:
+            registry:
+                image: registry:2
+                ports:
+                    - 5000:5000
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
+
+            - name: Mark the workspace as safe
+              # https://github.com/actions/checkout/issues/766
+              run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
+            - name: Check plugin streaming output is reassembled and printed properly
+              run: |
+                  scripts/test-plugin-output-streaming.sh

--- a/scripts/test-plugin-output-streaming.sh
+++ b/scripts/test-plugin-output-streaming.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Test that error output streamed from containertool is printed correctly by the plugin. 
+
+set -exo pipefail
+
+log() { printf -- "** %s\n" "$*" >&2; }
+error() { printf -- "** ERROR: %s\n" "$*" >&2; }
+fatal() { error "$@"; exit 1; }
+
+# Work in a temporary directory, deleted after the test finishes
+PKGPATH=$(mktemp -d)
+cleanup() {
+  log "Deleting temporary package $PKGPATH"
+  rm -rf "$PKGPATH"
+}
+trap cleanup EXIT
+
+swift package --package-path "$PKGPATH" init --type executable --name hello
+cat >> "$PKGPATH/Package.swift" <<EOF
+package.dependencies += [
+    .package(path: "$PWD"),
+]
+EOF
+
+# Run the plugin, forgetting a mandatory argument.   Verify that the output is not corrupted.
+# The `swift package` command will return a nonzero exit code.   This is expected, so disable pipefail.
+set +o pipefail
+swift package --package-path "$PKGPATH" --allow-network-connections all build-container-image 2>&1 | tee "$PKGPATH/output"
+set -o pipefail
+
+grep -F -x -e "error: Missing expected argument '--repository <repository>'" \
+           -e "error: Help:  --repository <repository>  Repository path" \
+           -e "error: Usage: containertool [<options>] --repository <repository> <executable>" \
+           -e "error:   See 'containertool --help' for more information." "$PKGPATH/output"
+
+echo Plugin error output: PASSED
+


### PR DESCRIPTION
Motivation
----------

`containertool` produces its normal output in single writes of less than PIPE_BUF bytes, which should be delivered atomically through the pipe to the plugin:

> Reading or writing pipe data is atomic if the size of data written is not greater than PIPE_BUF. This means that the data transfer seems to be an instantaneous unit, in that nothing else in the system can observe a state in which it is partially complete. Atomic I/O may not begin right away (it may need to wait for buffer space or for data), but once it does begin it finishes immediately.

https://www.gnu.org/software/libc/manual/html_node/Pipe-Atomicity.html

Progress messages written in this way are displayed correctly.   Unfortunately error output from `swift-argument-parser` is delivered in smaller chunks which are often broken across several lines by the plugin:

```
% swift package --allow-network-connections all  build-container-image       
Building for debugging...
[1/1] Write swift-version-2380AA06D3543E1B.txt
Build of product 'containertool' complete! (1.74s)
Building for debugging...
[0/3] Write swift-version-2380AA06D3543E1B.txt
Build of product 'hello-world' complete! (2.04s)
[ContainerImageBuilder] itory <repository>'
Help:  --repository <
[ContainerImageBuilder] repository>  Repository path
[ContainerImageBuilder] Usage: containertoo
[ContainerImageBuilder] l [<optio
[ContainerImageBuilder] ns>] --re
[ContainerImageBuilder] posito
[ContainerImageBuilder] ry <rep
error: Missing expected argument '--repos
[ContainerImageBuilder] ository
[ContainerImageBuilder] > <ex
[ContainerImageBuilder] ecutable>
  Se
[ContainerImageBuilder] e 'containertool --help' for more inf
[ContainerImageBuilder] ormation
[ContainerImageBuilder] .
```

At one point the plugin reassembled output from the pipe and re-split it on newlines, but the code triggered strict concurrency warnings with the Swift 6 language mode so it was removed in favour of `PIPE_BUF` write atomicity.   This commit restores the pipe output reassembly.

Modifications
-------------

* Plugin reassembles output from `containertool` and splits it on newlines
* All output after an error is now printed using `Diagnostics.error`.   Otherwise error and progress output would be interleaved.

Result
------

Error output from `containertool` will be presented correctly by the plugin.


Test Plan
---------

Existing tests continue to pass.
A new integration test checks that error output is not broken into multiple lines.