### PR TITLE
Examples: Adopt the structure used in hummingbird-examples

### DIFF
--- a/Examples/HelloWorldHummingbird/Package.swift
+++ b/Examples/HelloWorldHummingbird/Package.swift
@@ -21,9 +21,16 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.1.0"),
-        .package(url: "https://github.com/apple/swift-container-plugin", from: "0.4.0"),
+        .package(url: "https://github.com/apple/swift-container-plugin", from: "0.5.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
     ],
     targets: [
-        .executableTarget(name: "hello-world", dependencies: [.product(name: "Hummingbird", package: "hummingbird")])
+        .executableTarget(
+            name: "hello-world",
+            dependencies: [
+                .product(name: "Hummingbird", package: "hummingbird"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
+        )
     ]
 )

--- a/Examples/HelloWorldHummingbird/Sources/App.swift
+++ b/Examples/HelloWorldHummingbird/Sources/App.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftContainerPlugin open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftContainerPlugin project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftContainerPlugin project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+
+@main
+struct Hello: AsyncParsableCommand {
+    @Option(name: .shortAndLong)
+    var hostname: String = "0.0.0.0"
+
+    @Option(name: .shortAndLong)
+    var port: Int = 8080
+
+    func run() async throws {
+        let app = buildApplication(
+            configuration: .init(
+                address: .hostname(hostname, port: port),
+                serverName: "Hummingbird"
+            )
+        )
+        try await app.runService()
+    }
+}

--- a/Examples/HelloWorldHummingbird/Sources/Application+build.swift
+++ b/Examples/HelloWorldHummingbird/Sources/Application+build.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftContainerPlugin open source project
 //
-// Copyright (c) 2024 Apple Inc. and the SwiftContainerPlugin project authors
+// Copyright (c) 2025 Apple Inc. and the SwiftContainerPlugin project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -14,12 +14,22 @@
 
 import Foundation
 import Hummingbird
+import Logging
 
 let myos = ProcessInfo.processInfo.operatingSystemVersionString
 
-let router = Router()
-router.get { request, _ -> String in "Hello World, from Hummingbird on \(myos)\n" }
+func buildApplication(configuration: ApplicationConfiguration) -> some ApplicationProtocol {
+    let router = Router()
+    router.addMiddleware { LogRequestsMiddleware(.info) }
+    router.get("/") { _, _ in
+        "Hello World, from Hummingbird on \(myos)\n"
+    }
 
-let app = Application(router: router, configuration: .init(address: .hostname("0.0.0.0", port: 8080)))
+    let app = Application(
+        router: router,
+        configuration: configuration,
+        logger: Logger(label: "HelloWorldHummingbird")
+    )
 
-try await app.runService()
+    return app
+}


### PR DESCRIPTION
Motivation
----------

The [official Hummingbird examples](https://github.com/hummingbird-project/hummingbird-examples) split the server into a main entry point file and a separate build function.   Adopting the same structure makes this example more more familiar to users who are used to the official examples.

Modifications
-------------

Adopt the Hummingbird example structure for `HelloWorldHummingbird`

Result
------

The example works in the same way as before but has a more familiar structure for Hummingbird users.

Test Plan
---------

All tests continue to pass.