### PR TITLE
docs: Use swift-docc-plugin to preview documentation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"4.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-http-types.git", from: "1.2.0"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"4.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-http-types.git", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
     ],
     targets: [
         .target(

--- a/Sources/ContainerImageBuilderPluginDocumentation/README.md
+++ b/Sources/ContainerImageBuilderPluginDocumentation/README.md
@@ -3,4 +3,10 @@
 `ContainerImageBuilderPluginDocumentation` is an otherwise empty target that includes high-level,
 user-facing documentation about using the ContainerImageBuilder plugin from the command-line.
 
+To preview the documentation, run the following command:
+
+```bash
+swift package --disable-sandbox preview-documentation --target ContainerImageBuilderPlugin
+```
+
 <!-- Copyright (c) 2024 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
### Motivation

Makes it easier to preview documentation changes

### Modifications

* Add dependency on swift-docc-plugin
* Add detail on how to preview into the README within the documentation target

### Result

Documentation changes can be previewed by running the following command:
```
swift package --disable-sandbox preview-documentation --target ContainerImageBuilderPlugin
```

### Test Plan

No functional change.



