### PR TITLE
docs: Update CONTRIBUTING to reference soundness checks and remove advice to run locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,29 +54,7 @@ A good patch is:
 3. Documented, adding API documentation as needed to cover new functions and properties.
 4. Accompanied by a great commit message, using our commit message template.
 
-### Run `./scripts/soundness.sh`
-
-The scripts directory contains a [soundness.sh script](https://github.com/apple/swift-container-plugin/blob/main/scripts/soundness.sh)
-that enforces additional checks, like license headers and formatting style.
-
-Please make sure to `./scripts/soundness.sh` before pushing a change upstream, otherwise it is likely the PR validation will fail
-on minor changes such as a missing `self.` or similar formatting issues.
-
-For frequent contributors, we recommend adding the script as a [git pre-push hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks), which you can do via executing the following command in the project root directory: 
-
-```bash
-cat << EOF > .git/hooks/pre-push
-
-if [[ -f "scripts/soundness.sh" ]]; then
-  scripts/soundness.sh
-fi
-EOF
-```
-
-Which makes the script execute, and only allow the `git push` to complete if the check has passed.
-
-In the case of formatting issues, you can then `git add` the formatting changes, and attempt the push again. 
-
 ## How to contribute your work
 
-Please open a pull request at https://github.com/apple/swift-container-plugin. Make sure the CI passes, and then wait for code review.
+Please open a pull request at https://github.com/apple/swift-container-plugin. 
+Continuous integration (CI) checks for required content (headers), runs a variety of tests, and verifies the documentation builds. All pull requests should pass CI checks before a code review.


### PR DESCRIPTION
### Motivation

scripts/soundness.sh was deleted in #5 which moved CI to GitHub Actions.

resolves #96 

### Modifications

Remove the instruction to run `scripts/soundness.sh` from `CONTRIBUTING.md`.

### Result

Documentation no longer refers to nonexistent scripts.

### Test Plan

No functional change.
