### PR TITLE
docs: Fix broken examples links

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ Trying to pull registry.example.com/myservice@sha256:a3f75d0932d052dd9d448a1c904
 
 * Swift Container Plugin runs on macOS and Linux and requires Swift 6.0 or later.
 * On macOS you must install a cross-compilation Swift SDK, such as the [Swift Static Linux SDK](https://www.swift.org/documentation/articles/static-linux-getting-started.html), in order to build executables which can run on Linux-based cloud infrastructure.
-* A container runtime is not required to build an image, but one must be available wherever the image is to be run.  
+* A container runtime is not required to build an image, but one must be available wherever the image is to be run.
 
 ## Getting Started
 
-Learn more about setting up your project in the [ContainerImageBuilder plugin documentation](Sources/ContainerImageBuilderPluginDocumentation/Documentation.docc/ContainerImageBuilderPlugin.md).
+Learn more about setting up your project in the [plugin documentation](https://swiftpackageindex.com/apple/swift-container-plugin/documentation/containerimagebuilderplugin).
 
 Take a look at the [Examples](Examples).

--- a/Sources/swift-container-plugin/Documentation.docc/Adding-the-plugin-to-your-project.md
+++ b/Sources/swift-container-plugin/Documentation.docc/Adding-the-plugin-to-your-project.md
@@ -11,7 +11,7 @@ Swift Container Plugin is distributed as a Swift Package Manager package.    To 
 > Adding the same dependency to your project more than once will prevent it from building.
 > If this happens, delete the duplicate dependency lines from `Package.swift` and rebuild.
 
-Recent versions of `swift package` suupport the `add-dependency` command:
+Recent versions of `swift package` support the `add-dependency` command:
 
 ```shell
 swift package add-dependency https://github.com/apple/swift-container-plugin --from 0.5.0

--- a/Sources/swift-container-plugin/Documentation.docc/Swift-Container-Plugin.md
+++ b/Sources/swift-container-plugin/Documentation.docc/Swift-Container-Plugin.md
@@ -65,7 +65,7 @@ Trying to pull registry.example.com/myservice@sha256:a3f75d0932d052dd9d448a1c904
 2024-05-26T22:57:50+0000 info HummingBird : [HummingbirdCore] Server started and listening on 0.0.0.0:8080
 ```
 
-Take a look at the [Examples](Examples).
+Take a look at some [other examples](https://github.com/apple/swift-container-plugin/tree/main/Examples).
 
 ## Topics
 


### PR DESCRIPTION

Motivation
----------

Restructuring the documentation has left some broken links.

Modifications
-------------

* The examples link in the top level README should point to the documentation on Swift Package Index.
* The examples link in the top level DoCC page should point to the examples directory on GitHub.

Result
------

All links point to the correct pages.

Test Plan
---------

Tested manually.