### PR TITLE
docs: Update documentation links and examples after 1.0.0 release

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,5 +2,4 @@ version: 1
 builder:
   configs:
     - documentation_targets:
-        - containertool
         - swift-container-plugin

--- a/Examples/HelloWorldHummingbird/Package.swift
+++ b/Examples/HelloWorldHummingbird/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.1.0"),
-        .package(url: "https://github.com/apple/swift-container-plugin", from: "0.5.0"),
+        .package(url: "https://github.com/apple/swift-container-plugin", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
     ],
     targets: [

--- a/Examples/HelloWorldVapor/Package.swift
+++ b/Examples/HelloWorldVapor/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     platforms: [.macOS(.v13)],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor", from: "4.102.0"),
-        .package(url: "https://github.com/apple/swift-container-plugin", from: "0.5.0"),
+        .package(url: "https://github.com/apple/swift-container-plugin", from: "1.0.0"),
     ],
     targets: [.executableTarget(name: "hello-world", dependencies: [.product(name: "Vapor", package: "vapor")])]
 )

--- a/Examples/HelloWorldWithResources/Package.swift
+++ b/Examples/HelloWorldWithResources/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.1.0"),
-        .package(url: "https://github.com/apple/swift-container-plugin", from: "0.5.0"),
+        .package(url: "https://github.com/apple/swift-container-plugin", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Swift Container Plugin
 
-[![](https://img.shields.io/badge/docc-read_documentation-blue)](https://swiftpackageindex.com/apple/swift-container-plugin/documentation/containerimagebuilderplugin)
+[![](https://img.shields.io/badge/docc-read_documentation-blue)](https://swiftpackageindex.com/apple/swift-container-plugin/documentation/swift-container-plugin)
 [![](https://img.shields.io/github/v/release/apple/swift-container-plugin?include_prereleases)](https://github.com/apple/swift-container-plugin/releases)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fapple%2Fswift-container-plugin%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/apple/swift-container-plugin)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fapple%2Fswift-container-plugin%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/apple/swift-container-plugin)
@@ -69,6 +69,6 @@ Trying to pull registry.example.com/myservice@sha256:a3f75d0932d052dd9d448a1c904
 
 ## Getting Started
 
-Learn more about setting up your project in the [plugin documentation](https://swiftpackageindex.com/apple/swift-container-plugin/documentation/containerimagebuilderplugin).
+Learn more about setting up your project in the [plugin documentation](https://swiftpackageindex.com/apple/swift-container-plugin/documentation/swift-container-plugin).
 
 Take a look at the [Examples](Examples).


### PR DESCRIPTION
Motivation
----------

The DoCC documentation was restructured substantially between 0.5.0 and 1.0.0, so the links in `README.md` are no longer correct.    The examples should also point to the new release. 

Modifications
-------------

* Update the links to the Swift Package Index documentation
* Update example project dependencies 
* Stop asking SPI to build the `containertool` documentation target 
 
Result
------

Documentation links will be correct once Swift Package Index builds the new release.
 
Test Plan
---------

All existing tests continue to pass.