### PR TITLE
docs: Point to main branch documentation on Swift Package Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Swift Container Plugin
 
-[![](https://img.shields.io/badge/docc-read_documentation-blue)](https://swiftpackageindex.com/apple/swift-container-plugin/documentation/swift-container-plugin)
+[![](https://img.shields.io/badge/docc-read_documentation-blue)](https://swiftpackageindex.com/apple/swift-container-plugin/main/documentation/swift-container-plugin)
 [![](https://img.shields.io/github/v/release/apple/swift-container-plugin?include_prereleases)](https://github.com/apple/swift-container-plugin/releases)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fapple%2Fswift-container-plugin%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/apple/swift-container-plugin)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fapple%2Fswift-container-plugin%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/apple/swift-container-plugin)
@@ -69,6 +69,6 @@ Trying to pull registry.example.com/myservice@sha256:a3f75d0932d052dd9d448a1c904
 
 ## Getting Started
 
-Learn more about setting up your project in the [plugin documentation](https://swiftpackageindex.com/apple/swift-container-plugin/documentation/swift-container-plugin).
+Learn more about setting up your project in the [plugin documentation](https://swiftpackageindex.com/apple/swift-container-plugin/main/documentation/swift-container-plugin).
 
 Take a look at the [Examples](Examples).

--- a/Sources/swift-container-plugin/Documentation.docc/Swift-Container-Plugin.md
+++ b/Sources/swift-container-plugin/Documentation.docc/Swift-Container-Plugin.md
@@ -29,7 +29,7 @@ To use the plugin:
 ### Build and publish a container image
 
 After adding the plugin to your project, you can build and publish a container image in one step.
-Here is how to build the [HelloWorld example](https://github.com/apple/swift-container-plugin/tree/main/Examples/HelloWorldHummingbird) as a static executable for Linux running the `x86_64` architecture:
+Here is how to build the [HelloWorld example](https://github.com/apple/swift-container-plugin/tree/main/Examples/HelloWorldHummingbird) as a static executable for Linux running on the `x86_64` architecture:
 
 ```
 % swift package --swift-sdk x86_64-swift-linux-musl \


### PR DESCRIPTION
Motivation
----------

By default, Swift Package Index shows the documentation for the latest release.   This still has the `containertool` documentation target in `.spi.yml`, which is causing the left-hand navigation bar (the curation) to show the topics for `containertool` even though the main content is the Swift Container Plugin Documentation.

This should be resolved when the next release is tagged, but in the meantime linking to the `main` branch documentation will cause users to see the most up-to-date documentation with the correct navigation bar.

Modifications
-------------

Links to the SPI documentation in `README.md` point to the `main` branch.

Result
------

Users should see the latest documentation, with the correct navigation bar.

Test Plan
---------

No functional change.
All existing tests continue to pass.