### PR TITLE
containertool: Read default username and password from the environment

### DIFF
--- a/Sources/containertool/containertool.swift
+++ b/Sources/containertool/containertool.swift
@@ -40,10 +40,10 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
     @Option(help: "Resource bundle directory")
     private var resources: [String] = []
 
-    @Option(help: "Username")
+    @Option(help: "Default username, used if there are no matching entries in .netrc")
     private var username: String?
 
-    @Option(help: "Password")
+    @Option(help: "Default password, used if there are no matching entries in .netrc")
     private var password: String?
 
     @Flag(name: .shortAndLong, help: "Verbose output")
@@ -75,6 +75,8 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
 
         let env = ProcessInfo.processInfo.environment
         let defaultRegistry = defaultRegistry ?? env["CONTAINERTOOL_DEFAULT_REGISTRY"] ?? "docker.io"
+        let username = username ?? env["CONTAINERTOOL_USERNAME"]
+        let password = password ?? env["CONTAINERTOOL_PASSWORD"]
         let from = from ?? env["CONTAINERTOOL_BASE_IMAGE"] ?? "swift:slim"
         let os = os ?? env["CONTAINERTOOL_OS"] ?? "linux"
 


### PR DESCRIPTION
Motivation
----------

The `--username` and `--password` options allow default credentials to be defined.   These are used if a corresponding entry cannot be found in `.netrc`, or if the `--disable-netrc` flag is set.    (`--username` and `--password` should possibly be renamed to `--default-username` and `--default-password` to make this clearer.)

Specifying passwords as command line arguments is generally discouraged because they will then be visible in the the output of tools such as `ps` and `top`.   Providing credentials in environment variables avoids this problem, although there may still be other ways for users on the same machine to discover their values.

Environment variables are also more convenient than `.netrc` when uploading to registries which use short-lived credentials, such as ECR:

    export CONTAINERTOOL_USERNAME=AWS
    export CONTAINERTOOL_PASSWORD=$(aws ecr get-login-password --region us-west-2)
    swift run containertool --repository \
        123456789012.dkr.ecr.us-west-2.amazonaws.com/hello/world \
        .build/x86_64-swift-linux-musl/debug/hello-world

In the example above, if .netrc contains credentials for 123456789012.dkr.ecr.us-west-2.amazonaws.com they will be used in preference to the credentials in the environment variables. To avoid this, credentials which are not intended to be used should be removed from .netrc.

Modifications
-------------

If the `--username` or `--password` flags are not present on the command line, use the values of the `CONTAINERTOOL_USERNAME` or `CONTAINERTOOL_PASSWORD` environment variables - if defined - as the default credentials.

Result
------

* It is possible to define the default username and password without specifying their values on the command line, reducing the risk of leaking credentials to other users on the same system.
* It is possible to work with short-term credentials without needing to edit `.netrc` frequently.

Fixes #105

Test Plan
---------

All existing tests continue to pass.
Tested manually with a registry using short-lived credentials.