### PR TITLE
docs: Correct help text for --username and --password

### DIFF
--- a/Sources/swift-container-plugin/Documentation.docc/build-container-image.md
+++ b/Sources/swift-container-plugin/Documentation.docc/build-container-image.md
@@ -34,16 +34,16 @@ Wrap a binary in a container image and publish it.
   If the `product` being packaged has a [resource bundle](https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package) it will be added to the image automatically.
 
 - term  `--username <username>`:
-  Username to use when logging into the registry.
+  Default username to use when logging into the registry.
 
+  This username is used if there is no matching `.netrc` entry for the registry, there is no `.netrc` file, or the `--disable-netrc` option is set.
   The same username is used for the source and destination registries.
-  The `.netrc` file is ignored when this option is specified.
 
 - term  `--password <password>`:
-  Password to use when logging into the registry.
+  Default password to use when logging into the registry.
 
+  This password is used if there is no matching `.netrc` entry for the registry, there is no `.netrc` file, or the `--disable-netrc` option is set.
   The same password is used for the source and destination registries.
-  The `.netrc` file is ignored when this option is specified.
 
 - term  `-v, --verbose`:
   Verbose output.


### PR DESCRIPTION
Motivation
----------

The help text for `--username` and `--password` states that these options override `.netrc`.  In fact they are used as defaults if no suitable entry is found in `.netrc`.

Modifications
-------------

Correct the `--help` option descriptions and manual page.
 
Result
------

Help and documentation accurately describe what the options do.

Test Plan
---------

All existing tests continue to pass.   No functional change.