### PR TITLE
containertool: Correct help text for --username and --password

### DIFF
--- a/Sources/containertool/containertool.swift
+++ b/Sources/containertool/containertool.swift
@@ -40,10 +40,10 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
     @Option(help: "Resource bundle directory")
     private var resources: [String] = []
 
-    @Option(help: "Username")
+    @Option(help: "Default username, used if there are no matching entries in .netrc")
     private var username: String?
 
-    @Option(help: "Password")
+    @Option(help: "Default password, used if there are no matching entries in .netrc")
     private var password: String?
 
     @Flag(name: .shortAndLong, help: "Verbose output")


### PR DESCRIPTION
Motivation
----------

The help text for `--username` and `--password` states that these options override `.netrc`.  In fact they are used as defaults if no suitable entry is found in `.netrc`.

This pull request cherry picks the help text changes from #119, without introducing the new environment variables.

Modifications
-------------

Correct the option descriptions in the manual page.

Result
------

Documentation accurately describes what the options do.

Test Plan
---------

All existing tests continue to pass.   No functional change.