### PR TITLE
containertool: Rename --username/password to --default-username/password

### DIFF
--- a/Sources/swift-container-plugin/Documentation.docc/build-container-image.md
+++ b/Sources/swift-container-plugin/Documentation.docc/build-container-image.md
@@ -33,13 +33,13 @@ Wrap a binary in a container image and publish it.
 
   If the `product` being packaged has a [resource bundle](https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package) it will be added to the image automatically.
 
-- term  `--username <username>`:
+- term  `--default-username <username>`:
   Default username to use when logging into the registry.
 
   This username is used if there is no matching `.netrc` entry for the registry, there is no `.netrc` file, or the `--disable-netrc` option is set.
   The same username is used for the source and destination registries.
 
-- term  `--password <password>`:
+- term  `--default-password <password>`:
   Default password to use when logging into the registry.
 
   This password is used if there is no matching `.netrc` entry for the registry, there is no `.netrc` file, or the `--disable-netrc` option is set.


### PR DESCRIPTION
Motivation
----------

The `--username` and `--password` options define default values which are used if no suitable credentials can be found in `.netrc`.  Their current names could imply that they override other sources of credentials - the help originally said this was the case (#123).   Renaming them to `--default-username` and `--default-password` reduces the risk of misunderstanding.

Modifications
-------------

* Rename the `--user` and `--password` options to `--default-user` and `--default-password`.
* Add checks to warn that the old versions are deprecated, and fail if both are provided together.
* Hide the old options from `--help` and remove them from the manual page
* Rename the environment variable versions of these options.   The environment variable change had not yet been released so deprecation warnings are not needed.

Result
------

* New users will see more descriptive option names
* Existing users will be prompted to change the options they pass

Test Plan
---------

All existing test continue to pass.