### PR TITLE
containertool: Allow destination repository to be set by an environment variable

### DIFF
--- a/Examples/HelloWorldHummingbird/Package.swift
+++ b/Examples/HelloWorldHummingbird/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.1.0"),
-        .package(url: "https://github.com/apple/swift-container-plugin", from: "1.0.0"),
+        .package(path: "../.."),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
     ],
     targets: [

--- a/Sources/containertool/containertool.swift
+++ b/Sources/containertool/containertool.swift
@@ -32,7 +32,7 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
     private var defaultRegistry: String?
 
     @Option(help: "Repository path")
-    private var repository: String
+    private var repository: String?
 
     @Argument(help: "Executable to package")
     private var executable: String
@@ -114,7 +114,14 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
         // MARK: Apply defaults for unspecified configuration flags
 
         let env = ProcessInfo.processInfo.environment
+
         let defaultRegistry = defaultRegistry ?? env["CONTAINERTOOL_DEFAULT_REGISTRY"] ?? "docker.io"
+        guard let repository = repository ?? env["CONTAINERTOOL_REPOSITORY"] else {
+            throw ValidationError(
+                "Please specify the destination repository using --repository or CONTAINERTOOL_REPOSITORY"
+            )
+        }
+
         let username = defaultUsername ?? env["CONTAINERTOOL_DEFAULT_USERNAME"]
         let password = defaultPassword ?? env["CONTAINERTOOL_DEFAULT_PASSWORD"]
         let from = from ?? env["CONTAINERTOOL_BASE_IMAGE"] ?? "swift:slim"

--- a/Sources/swift-container-plugin/Documentation.docc/build-container-image.md
+++ b/Sources/swift-container-plugin/Documentation.docc/build-container-image.md
@@ -20,7 +20,7 @@ Wrap a binary in a container image and publish it.
 - term  `--default-registry <default-registry>`:
   The default registry hostname. (default: `docker.io`)
 
-  If the value of the `--repository` argument does not contain a registry hostname, the default registry will be prepended to the repository path.
+  If the repository path does not contain a registry hostname, the default registry will be prepended to it.
 
 - term  `--repository <repository>`:
   The repository path.
@@ -79,8 +79,13 @@ Wrap a binary in a container image and publish it.
 ### Environment
 
 - term `CONTAINERTOOL_DEFAULT_REGISTRY`:
-  Default image registry hostname, used when the `--repository` argument does not contain a registry hostname.
+  Default image registry hostname, used when the repository path does not contain a registry hostname.
   (default: `docker.io`)
+
+- term `CONTAINERTOOL_REPOSITORY`:
+  The repository path.
+
+  If the path does not begin with a registry hostname, the default registry will be prepended to the path.
 
 - term `CONTAINERTOOL_BASE_IMAGE`:
   Base image on which to layer the application.

--- a/scripts/test-plugin-output-streaming.sh
+++ b/scripts/test-plugin-output-streaming.sh
@@ -46,9 +46,8 @@ swift package --package-path "$PKGPATH" --allow-network-connections all build-co
 set -o pipefail
 
 # This checks that the output lines are not broken, but not that they appear in the correct order
-grep -F -x -e "error: Missing expected argument '--repository <repository>'" \
-           -e "error: Help:  --repository <repository>  Repository path" \
-           -e "error: Usage: containertool [<options>] --repository <repository> <executable>" \
+grep -F -x -e "error: Please specify the destination repository using --repository or CONTAINERTOOL_REPOSITORY" \
+           -e "error: Usage: containertool [<options>] <executable>" \
            -e "error:   See 'containertool --help' for more information." "$PKGPATH/output"
 
 log Plugin error output: PASSED


### PR DESCRIPTION
Motivation
----------

It is currently only possible to set the destination repository by specifying the mandatory `--repository` flag.   Setting the repository from an environment variable can be more convenient in scripts and in the terminal - the destination repository can be set once and inherited by all further builds in the same shell.

Modifications
-------------

* `--repository` is no longer a mandatory argument.
* A new `CONTAINERTOOL_REPOSITORY` environment variable is used if `--repository` is not set.

Fixes #100 

Result
------

Either `--repository` or `CONTAINERTOOL_REPOSITORY` can be used to define the destination repository.   The command line flag takes precedence over the environment variable.

Test Plan
---------

All existing tests continue to pass.