### PR TITLE
containertool: Arrange options into related groups

### DIFF
--- a/Sources/containertool/containertool.swift
+++ b/Sources/containertool/containertool.swift
@@ -36,7 +36,7 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
         @Option(help: "The default container registry to use when the image reference doesn't specify one")
         var defaultRegistry: String?
 
-        @Option(help: "Destination image reference")
+        @Option(help: "The name and optional tag for the generated container image")
         var repository: String?
 
         @Option(help: "The tag for the generated container image")

--- a/Sources/containertool/containertool.swift
+++ b/Sources/containertool/containertool.swift
@@ -42,7 +42,7 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
         @Option(help: "The tag for the generated container image")
         var tag: String?
 
-        @Option(help: "Base image reference")
+        @Option(help: "The base container image name and optional tag")
         var from: String?
     }
 

--- a/Sources/containertool/containertool.swift
+++ b/Sources/containertool/containertool.swift
@@ -33,7 +33,7 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
 
     /// Options controlling the locations of the source and destination images
     struct RepositoryOptions: ParsableArguments {
-        @Option(help: "Default registry for image references which do not specify one")
+        @Option(help: "The default container registry to use when the image reference doesn't specify one")
         var defaultRegistry: String?
 
         @Option(help: "Destination image reference")

--- a/Sources/containertool/containertool.swift
+++ b/Sources/containertool/containertool.swift
@@ -39,7 +39,7 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
         @Option(help: "Destination image reference")
         var repository: String?
 
-        @Option(help: "Destination image tag")
+        @Option(help: "The tag for the generated container image")
         var tag: String?
 
         @Option(help: "Base image reference")

--- a/Sources/containertool/containertool.swift
+++ b/Sources/containertool/containertool.swift
@@ -91,7 +91,7 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
         )
         var password: String?
 
-        @Option(help: "Default password, used if there are no matching entries in .netrc")
+        @Option(help: "The default password to use if the tool can't find a matching entry in .netrc")
         var defaultPassword: String?
 
         @Flag(inversion: .prefixedEnableDisable, exclusivity: .exclusive, help: "Load credentials from a netrc file")

--- a/Sources/swift-container-plugin/Documentation.docc/build-container-image.md
+++ b/Sources/swift-container-plugin/Documentation.docc/build-container-image.md
@@ -8,7 +8,7 @@ Wrap a binary in a container image and publish it.
 
 ### Usage
 
-`swift package build-container-image [<options>] --repository <repository>`
+`swift package build-container-image [<options>]`
 
 ### Options
 
@@ -17,21 +17,46 @@ Wrap a binary in a container image and publish it.
 
   If `Package.swift` defines only one product, it will be selected by default.
 
+### Source and destination repository options
+
 - term  `--default-registry <default-registry>`:
   The default registry hostname. (default: `docker.io`)
 
   If the repository path does not contain a registry hostname, the default registry will be prepended to it.
 
 - term  `--repository <repository>`:
-  The repository path.
+  Destination image repository.
 
-  If the path does not begin with a registry hostname, the default registry will be prepended to the path.
+  If the repository path does not begin with a registry hostname, the default registry will be prepended to the path.
+  The destination repository must be specified, either by setting the `--repository` option or the `CONTAINERTOOL_REPOSITORY` environment variable.
+
+- term  `--tag <tag>`:
+  Destination image tag.
+
+  The `latest` tag is automatically updated to refer to the published image.
+
+- term  `--from <from>`:
+  Base image reference. (default: `swift:slim`)
+
+### Image build options
 
 - term  `--resources <resources>`:
   Add the file or directory at `resources` to the image.
   Directories are added recursively.
 
   If the `product` being packaged has a [resource bundle](https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package) it will be added to the image automatically.
+
+### Image configuration options
+
+- term  `--architecture <architecture>`:
+  CPU architecture required to run the image.
+
+  If the base image is `scratch`, the final image will have no base layer and will consist only of the application layer and resource bundle layer, if the product has a resource bundle.
+
+- term  `--os <os>`:
+  Operating system required to run the image. (default: `linux`)
+
+### Authentication options
 
 - term  `--default-username <username>`:
   Default username to use when logging into the registry.
@@ -45,33 +70,19 @@ Wrap a binary in a container image and publish it.
   This password is used if there is no matching `.netrc` entry for the registry, there is no `.netrc` file, or the `--disable-netrc` option is set.
   The same password is used for the source and destination registries.
 
-- term  `-v, --verbose`:
-  Verbose output.
-
-- term  `--allow-insecure-http <allow-insecure-http>`:
-  Connect to the container registry using plaintext HTTP. (values: `source`, `destination`, `both`)
-
-- term  `--architecture <architecture>`:
-  CPU architecture to record in the image.
-
-- term  `--from <from>`:
-  Base image reference. (default: `swift:slim`)
-
-  If the base image is `scratch`, the final image will have no base layer and will consist only of the application layer and resource bundle layer, if the product has a resource bundle.
-
-- term  `--os <os>`:
-  Operating system to record in the image. (default: `linux`)
-
-- term  `--tag <tag>`:
-  Tag for this manifest.
-
-  The `latest` tag is automatically updated to refer to the published image.
-
 - term  `--enable-netrc/--disable-netrc`:
   Load credentials from a netrc file (default: `--enable-netrc`)
 
 - term  `--netrc-file <netrc-file>`:
   The path to the `.netrc` file.
+
+- term  `--allow-insecure-http <allow-insecure-http>`:
+  Connect to the container registry using plaintext HTTP. (values: `source`, `destination`, `both`)
+
+### Options
+
+- term  `-v, --verbose`:
+  Verbose output.
 
 - term  `-h, --help`:
   Show help information.
@@ -83,14 +94,15 @@ Wrap a binary in a container image and publish it.
   (default: `docker.io`)
 
 - term `CONTAINERTOOL_REPOSITORY`:
-  The repository path.
+  The destination image repository.
 
   If the path does not begin with a registry hostname, the default registry will be prepended to the path.
+  The destination repository must be specified, either by setting the `--repository` option or the `CONTAINERTOOL_REPOSITORY` environment variable.
 
 - term `CONTAINERTOOL_BASE_IMAGE`:
   Base image on which to layer the application.
   (default: `swift:slim`)
 
 - term `CONTAINERTOOL_OS`:
-  Operating system to encode in the container image.
+  Operating system.
   (default: `Linux`)

--- a/Sources/swift-container-plugin/Documentation.docc/build-container-image.md
+++ b/Sources/swift-container-plugin/Documentation.docc/build-container-image.md
@@ -31,7 +31,7 @@ Wrap a binary in a container image and publish it.
   The destination repository must be specified, either by setting the `--repository` option or the `CONTAINERTOOL_REPOSITORY` environment variable.
 
 - term  `--tag <tag>`:
-  Destination image tag.
+  The tag to apply to the destination image.
 
   The `latest` tag is automatically updated to refer to the published image.
 


### PR DESCRIPTION
Motivation
----------

Arranging related options together in groups makes it easier for users to find relevant options.   This will be even more beneficial as more options are added (e.g. #91).

Modifications
-------------

* Arrange `containertool`'s command line options into related groups with headings.
* Update `build-container-image` manual page to match the new groupings.

Result
------

* Users will be able to find help for specific options more easily.
* Grouping options together may also help them to discover new options related the tasks they are trying to achieve.

Test Plan
---------

* No functional change. 
* All existing tests continue to pass.