### PR TITLE
ContainerRegistry: Reject invalid image tags and digests

### DIFF
--- a/Sources/ContainerRegistry/Blobs.swift
+++ b/Sources/ContainerRegistry/Blobs.swift
@@ -65,9 +65,7 @@ extension RegistryClient {
 extension HTTPField.Name { static let dockerContentDigest = Self("Docker-Content-Digest")! }
 
 public extension RegistryClient {
-    func blobExists(repository: ImageReference.Repository, digest: String) async throws -> Bool {
-        precondition(digest.count > 0)
-
+    func blobExists(repository: ImageReference.Repository, digest: ImageReference.Digest) async throws -> Bool {
         do {
             let _ = try await executeRequestThrowing(
                 .head(repository, path: "blobs/\(digest)"),
@@ -84,10 +82,8 @@ public extension RegistryClient {
     ///   - digest: Digest of the blob.
     /// - Returns: The downloaded data.
     /// - Throws: If the blob download fails.
-    func getBlob(repository: ImageReference.Repository, digest: String) async throws -> Data {
-        precondition(digest.count > 0, "digest must not be an empty string")
-
-        return try await executeRequestThrowing(
+    func getBlob(repository: ImageReference.Repository, digest: ImageReference.Digest) async throws -> Data {
+        try await executeRequestThrowing(
             .get(repository, path: "blobs/\(digest)", accepting: ["application/octet-stream"]),
             decodingErrors: [.notFound]
         )
@@ -106,10 +102,10 @@ public extension RegistryClient {
     /// in the registry as plain blobs with MIME type "application/octet-stream".
     /// This function attempts to decode the received data without reference
     /// to the MIME type.
-    func getBlob<Response: Decodable>(repository: ImageReference.Repository, digest: String) async throws -> Response {
-        precondition(digest.count > 0, "digest must not be an empty string")
-
-        return try await executeRequestThrowing(
+    func getBlob<Response: Decodable>(repository: ImageReference.Repository, digest: ImageReference.Digest) async throws
+        -> Response
+    {
+        try await executeRequestThrowing(
             .get(repository, path: "blobs/\(digest)", accepting: ["application/octet-stream"]),
             decodingErrors: [.notFound]
         )

--- a/Sources/ContainerRegistry/Manifests.swift
+++ b/Sources/ContainerRegistry/Manifests.swift
@@ -13,12 +13,14 @@
 //===----------------------------------------------------------------------===//
 
 public extension RegistryClient {
-    func putManifest(repository: ImageReference.Repository, reference: String, manifest: ImageManifest) async throws
+    func putManifest(
+        repository: ImageReference.Repository,
+        reference: any ImageReference.Reference,
+        manifest: ImageManifest
+    ) async throws
         -> String
     {
         // See https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pushing-manifests
-        precondition("\(reference)".count > 0, "reference must not be an empty string")
-
         let httpResponse = try await executeRequestThrowing(
             // All blob uploads have Content-Type: application/octet-stream on the wire, even if mediatype is different
             .put(
@@ -42,11 +44,11 @@ public extension RegistryClient {
             .absoluteString
     }
 
-    func getManifest(repository: ImageReference.Repository, reference: String) async throws -> ImageManifest {
+    func getManifest(repository: ImageReference.Repository, reference: any ImageReference.Reference) async throws
+        -> ImageManifest
+    {
         // See https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests
-        precondition(reference.count > 0, "reference must not be an empty string")
-
-        return try await executeRequestThrowing(
+        try await executeRequestThrowing(
             .get(
                 repository,
                 path: "manifests/\(reference)",
@@ -60,10 +62,11 @@ public extension RegistryClient {
         .data
     }
 
-    func getIndex(repository: ImageReference.Repository, reference: String) async throws -> ImageIndex {
-        precondition(reference.count > 0, "reference must not be an empty string")
-
-        return try await executeRequestThrowing(
+    func getIndex(repository: ImageReference.Repository, reference: any ImageReference.Reference) async throws
+        -> ImageIndex
+    {
+        // See https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests
+        try await executeRequestThrowing(
             .get(
                 repository,
                 path: "manifests/\(reference)",

--- a/Sources/ContainerRegistry/RegistryClient+ImageConfiguration.swift
+++ b/Sources/ContainerRegistry/RegistryClient+ImageConfiguration.swift
@@ -21,7 +21,8 @@ extension RegistryClient {
     /// - Throws: If the blob cannot be decoded as an `ImageConfiguration`.
     ///
     /// Image configuration records are stored as blobs in the registry.  This function retrieves the requested blob and tries to decode it as a configuration record.
-    public func getImageConfiguration(forImage image: ImageReference, digest: String) async throws -> ImageConfiguration
+    public func getImageConfiguration(forImage image: ImageReference, digest: ImageReference.Digest) async throws
+        -> ImageConfiguration
     {
         try await getBlob(repository: image.repository, digest: digest)
     }

--- a/Sources/containertool/Extensions/Errors+CustomStringConvertible.swift
+++ b/Sources/containertool/Extensions/Errors+CustomStringConvertible.swift
@@ -60,3 +60,31 @@ extension ContainerRegistry.ImageReference.Repository.ValidationError: Swift.Cus
         }
     }
 }
+
+extension ContainerRegistry.ImageReference.Tag.ValidationError: Swift.CustomStringConvertible {
+    /// A human-readable string describing an image reference validation error
+    public var description: String {
+        switch self {
+        case .emptyString:
+            return "Invalid reference format: tag cannot be empty"
+        case .tooLong(let rawValue):
+            return "Invalid reference format: tag (\(rawValue)) is too long"
+        case .invalidReferenceFormat(let rawValue):
+            return "Invalid reference format: tag (\(rawValue)) contains invalid characters"
+        }
+    }
+}
+
+extension ContainerRegistry.ImageReference.Digest.ValidationError: Swift.CustomStringConvertible {
+    /// A human-readable string describing an image reference validation error
+    public var description: String {
+        switch self {
+        case .emptyString:
+            return "Invalid reference format: digest cannot be empty"
+        case .tooLong(let rawValue):
+            return "Invalid reference format: digest (\(rawValue)) is too long"
+        case .invalidReferenceFormat(let rawValue):
+            return "Invalid reference format: digest (\(rawValue)) is not a valid digest"
+        }
+    }
+}

--- a/Sources/containertool/Extensions/RegistryClient+CopyBlobs.swift
+++ b/Sources/containertool/Extensions/RegistryClient+CopyBlobs.swift
@@ -23,7 +23,7 @@ extension RegistryClient {
     ///   - destRepository: The repository on this registry to which the blob should be copied.
     /// - Throws: If the copy cannot be completed.
     func copyBlob(
-        digest: String,
+        digest: ImageReference.Digest,
         fromRepository sourceRepository: ImageReference.Repository,
         toClient destClient: RegistryClient,
         toRepository destRepository: ImageReference.Repository
@@ -39,6 +39,6 @@ extension RegistryClient {
         log("Layer \(digest): pushing")
         let uploaded = try await destClient.putBlob(repository: destRepository, data: blob)
         log("Layer \(digest): done")
-        assert(digest == uploaded.digest)
+        assert("\(digest)" == uploaded.digest)
     }
 }

--- a/Sources/containertool/Extensions/RegistryClient+Layers.swift
+++ b/Sources/containertool/Extensions/RegistryClient+Layers.swift
@@ -26,13 +26,16 @@ extension RegistryClient {
             return try await getManifest(repository: image.repository, reference: image.reference)
         } catch {
             // Try again, treating the top level object as an index.
-            // This could be more efficient if the exception thrown by getManfiest() included the data it was unable to parse
+            // This could be more efficient if the exception thrown by getManifest() included the data it was unable to parse
             let index = try await getIndex(repository: image.repository, reference: image.reference)
             guard let manifest = index.manifests.first(where: { $0.platform?.architecture == architecture }) else {
                 throw "Could not find a suitable base image for \(architecture)"
             }
             // The index should not point to another index;   if it does, this call will throw a final error to be handled by the caller.
-            return try await getManifest(repository: image.repository, reference: manifest.digest)
+            return try await getManifest(
+                repository: image.repository,
+                reference: ImageReference.Digest(manifest.digest)
+            )
         }
     }
 

--- a/Tests/ContainerRegistryTests/ImageReferenceTests.swift
+++ b/Tests/ContainerRegistryTests/ImageReferenceTests.swift
@@ -29,7 +29,7 @@ struct ReferenceTests {
             expected: try! ImageReference(
                 registry: "default",
                 repository: ImageReference.Repository("localhost"),
-                reference: "latest"
+                reference: ImageReference.Tag("latest")
             )
         ),
         ReferenceTestCase(
@@ -37,7 +37,7 @@ struct ReferenceTests {
             expected: try! ImageReference(
                 registry: "default",
                 repository: ImageReference.Repository("example.com"),
-                reference: "latest"
+                reference: ImageReference.Tag("latest")
             )
         ),
         ReferenceTestCase(
@@ -45,7 +45,7 @@ struct ReferenceTests {
             expected: try! ImageReference(
                 registry: "default",
                 repository: ImageReference.Repository("example"),
-                reference: "1234"
+                reference: ImageReference.Tag("1234")
             )
         ),
 
@@ -60,7 +60,7 @@ struct ReferenceTests {
             expected: try! ImageReference(
                 registry: "localhost",
                 repository: ImageReference.Repository("foo"),
-                reference: "latest"
+                reference: ImageReference.Tag("latest")
             )
         ),
         ReferenceTestCase(
@@ -68,7 +68,7 @@ struct ReferenceTests {
             expected: try! ImageReference(
                 registry: "localhost:1234",
                 repository: ImageReference.Repository("foo"),
-                reference: "latest"
+                reference: ImageReference.Tag("latest")
             )
         ),
         ReferenceTestCase(
@@ -76,7 +76,7 @@ struct ReferenceTests {
             expected: try! ImageReference(
                 registry: "example.com",
                 repository: ImageReference.Repository("foo"),
-                reference: "latest"
+                reference: ImageReference.Tag("latest")
             )
         ),
         ReferenceTestCase(
@@ -84,7 +84,7 @@ struct ReferenceTests {
             expected: try! ImageReference(
                 registry: "example.com:1234",
                 repository: ImageReference.Repository("foo"),
-                reference: "latest"
+                reference: ImageReference.Tag("latest")
             )
         ),
         ReferenceTestCase(
@@ -92,7 +92,7 @@ struct ReferenceTests {
             expected: try! ImageReference(
                 registry: "example.com:1234",
                 repository: ImageReference.Repository("foo"),
-                reference: "bar"
+                reference: ImageReference.Tag("bar")
             )
         ),
 
@@ -103,7 +103,7 @@ struct ReferenceTests {
             expected: try! ImageReference(
                 registry: "default",
                 repository: ImageReference.Repository("local/foo"),
-                reference: "latest"
+                reference: ImageReference.Tag("latest")
             )
         ),
         ReferenceTestCase(
@@ -111,7 +111,7 @@ struct ReferenceTests {
             expected: try! ImageReference(
                 registry: "default",
                 repository: ImageReference.Repository("example/foo"),
-                reference: "latest"
+                reference: ImageReference.Tag("latest")
             )
         ),
         ReferenceTestCase(
@@ -119,35 +119,28 @@ struct ReferenceTests {
             expected: try! ImageReference(
                 registry: "default",
                 repository: ImageReference.Repository("example/foo"),
-                reference: "1234"
+                reference: ImageReference.Tag("1234")
             )
         ),
 
         // Distribution spec tests
         ReferenceTestCase(
-            reference: "example.com/foo@sha256:0123456789abcdef01234567890abcdef",
+            reference: "example.com/foo@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
             expected: try! ImageReference(
                 registry: "example.com",
                 repository: ImageReference.Repository("foo"),
-                reference: "sha256:0123456789abcdef01234567890abcdef"
+                reference: ImageReference.Digest(
+                    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                )
             )
         ),
 
-        // This example goes against the distribution spec's regular expressions but matches observed client behaviour
         ReferenceTestCase(
             reference: "foo:1234/bar:1234",
             expected: try! ImageReference(
                 registry: "foo:1234",
                 repository: ImageReference.Repository("bar"),
-                reference: "1234"
-            )
-        ),
-        ReferenceTestCase(
-            reference: "localhost/foo:1234/bar:1234",
-            expected: try! ImageReference(
-                registry: "localhost",
-                repository: ImageReference.Repository("foo"),
-                reference: "1234/bar:1234"
+                reference: ImageReference.Tag("1234")
             )
         ),
 
@@ -157,7 +150,7 @@ struct ReferenceTests {
             expected: try! ImageReference(
                 registry: "EXAMPLE.COM",
                 repository: ImageReference.Repository("foo"),
-                reference: "latest"
+                reference: ImageReference.Tag("latest")
             )
         ),
     ]
@@ -205,7 +198,7 @@ struct ReferenceTests {
                 == ImageReference(
                     registry: "index.docker.io",
                     repository: ImageReference.Repository("library/swift"),
-                    reference: "slim"
+                    reference: ImageReference.Tag("slim")
                 )
         )
 
@@ -215,7 +208,7 @@ struct ReferenceTests {
                 == ImageReference(
                     registry: "index.docker.io",
                     repository: ImageReference.Repository("library/swift"),
-                    reference: "slim"
+                    reference: ImageReference.Tag("slim")
                 )
         )
 
@@ -225,7 +218,7 @@ struct ReferenceTests {
                 == ImageReference(
                     registry: "index.docker.io",
                     repository: ImageReference.Repository("library/swift"),
-                    reference: "slim"
+                    reference: ImageReference.Tag("slim")
                 )
         )
 
@@ -235,7 +228,7 @@ struct ReferenceTests {
                 == ImageReference(
                     registry: "index.docker.io",
                     repository: ImageReference.Repository("library/swift"),
-                    reference: "slim"
+                    reference: ImageReference.Tag("slim")
                 )
         )
 
@@ -245,7 +238,7 @@ struct ReferenceTests {
                 == ImageReference(
                     registry: "index.docker.io",
                     repository: ImageReference.Repository("library/swift"),
-                    reference: "latest"
+                    reference: ImageReference.Tag("latest")
                 )
         )
 
@@ -255,7 +248,7 @@ struct ReferenceTests {
                 == ImageReference(
                     registry: "localhost:5000",
                     repository: ImageReference.Repository("swift"),
-                    reference: "latest"
+                    reference: ImageReference.Tag("latest")
                 )
         )
 
@@ -264,7 +257,7 @@ struct ReferenceTests {
                 == ImageReference(
                     registry: "localhost:5000",
                     repository: ImageReference.Repository("swift"),
-                    reference: "latest"
+                    reference: ImageReference.Tag("latest")
                 )
         )
     }


### PR DESCRIPTION
Motivation
----------

Cherry pick of #140.

`ImageReference` does not check for illegal characters in parsed image digests and tags. This means that `containertool` will send illegal image
names to the registry. The registry will reject them, but the error message might not explain why, so a generic error message will be printed. Runtimes reject illegal image references immediately, without sending them to the registry.

Some desktop runtimes accept local image names which the registry will  reject; other runtimes reject these names even for local names. `containertool`
now also rejects them.

Modifications
-------------

* Check validity of tags and digests when parsing image names
* Change the low-level API functions to accept `Digest` or `Reference` instead of `String`.

Result
------

It is impossible to create a `Repository` object containing a malformed tag or digest, because the constructor checks the string value. It is impossible
to send a malformed name to the registry because the API wrappers only accept `Digest` or `Reference (Digest | Tag)` objects.

Fixes #139 

Test Plan
---------

Existing tests continue to pass.
New tests exercise additional checks which were previously missing. Removed tests which checked tags which seemed to be accepted by some desktop runtimes, but which were not accepted by registries.