### PR TITLE
ContainerRegistry: Remove return-type overloaded client functions

### DIFF
--- a/Sources/ContainerRegistry/Blobs.swift
+++ b/Sources/ContainerRegistry/Blobs.swift
@@ -76,28 +76,6 @@ public extension RegistryClient {
         .data
     }
 
-    /// Fetches a blob and tries to decode it as a JSON object.
-    ///
-    /// - Parameters:
-    ///   - repository: Name of the repository containing the blob.
-    ///   - digest: Digest of the blob.
-    /// - Returns: The decoded object.
-    /// - Throws: If the blob download fails or the blob cannot be decoded.
-    ///
-    /// Some JSON objects, such as ImageConfiguration, are stored
-    /// in the registry as plain blobs with MIME type "application/octet-stream".
-    /// This function attempts to decode the received data without reference
-    /// to the MIME type.
-    func getBlob<Response: Decodable>(repository: ImageReference.Repository, digest: ImageReference.Digest) async throws
-        -> Response
-    {
-        let (data, _) = try await executeRequestThrowing(
-            .get(repository, path: "blobs/\(digest)", accepting: ["application/octet-stream"]),
-            decodingErrors: [.notFound]
-        )
-        return try decoder.decode(Response.self, from: data)
-    }
-
     /// Uploads a blob to the registry.
     ///
     /// This function uploads a blob of unstructured data to the registry.

--- a/Sources/ContainerRegistry/Blobs.swift
+++ b/Sources/ContainerRegistry/Blobs.swift
@@ -91,11 +91,11 @@ public extension RegistryClient {
     func getBlob<Response: Decodable>(repository: ImageReference.Repository, digest: ImageReference.Digest) async throws
         -> Response
     {
-        try await executeRequestThrowing(
+        let (data, _) = try await executeRequestThrowing(
             .get(repository, path: "blobs/\(digest)", accepting: ["application/octet-stream"]),
             decodingErrors: [.notFound]
         )
-        .data
+        return try decoder.decode(Response.self, from: data)
     }
 
     /// Uploads a blob to the registry.

--- a/Sources/ContainerRegistry/Manifests.swift
+++ b/Sources/ContainerRegistry/Manifests.swift
@@ -17,9 +17,7 @@ public extension RegistryClient {
         repository: ImageReference.Repository,
         reference: any ImageReference.Reference,
         manifest: ImageManifest
-    ) async throws
-        -> String
-    {
+    ) async throws -> String {
         // See https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pushing-manifests
         let httpResponse = try await executeRequestThrowing(
             // All blob uploads have Content-Type: application/octet-stream on the wire, even if mediatype is different
@@ -44,11 +42,12 @@ public extension RegistryClient {
             .absoluteString
     }
 
-    func getManifest(repository: ImageReference.Repository, reference: any ImageReference.Reference) async throws
-        -> ImageManifest
-    {
+    func getManifest(
+        repository: ImageReference.Repository,
+        reference: any ImageReference.Reference
+    ) async throws -> ImageManifest {
         // See https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests
-        try await executeRequestThrowing(
+        let (data, _) = try await executeRequestThrowing(
             .get(
                 repository,
                 path: "manifests/\(reference)",
@@ -59,14 +58,15 @@ public extension RegistryClient {
             ),
             decodingErrors: [.notFound]
         )
-        .data
+        return try decoder.decode(ImageManifest.self, from: data)
     }
 
-    func getIndex(repository: ImageReference.Repository, reference: any ImageReference.Reference) async throws
-        -> ImageIndex
-    {
+    func getIndex(
+        repository: ImageReference.Repository,
+        reference: any ImageReference.Reference
+    ) async throws -> ImageIndex {
         // See https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests
-        try await executeRequestThrowing(
+        let (data, _) = try await executeRequestThrowing(
             .get(
                 repository,
                 path: "manifests/\(reference)",
@@ -77,6 +77,6 @@ public extension RegistryClient {
             ),
             decodingErrors: [.notFound]
         )
-        .data
+        return try decoder.decode(ImageIndex.self, from: data)
     }
 }

--- a/Sources/ContainerRegistry/RegistryClient+ImageConfiguration.swift
+++ b/Sources/ContainerRegistry/RegistryClient+ImageConfiguration.swift
@@ -21,10 +21,12 @@ extension RegistryClient {
     /// - Throws: If the blob cannot be decoded as an `ImageConfiguration`.
     ///
     /// Image configuration records are stored as blobs in the registry.  This function retrieves the requested blob and tries to decode it as a configuration record.
-    public func getImageConfiguration(forImage image: ImageReference, digest: ImageReference.Digest) async throws
-        -> ImageConfiguration
-    {
-        try await getBlob(repository: image.repository, digest: digest)
+    public func getImageConfiguration(
+        forImage image: ImageReference,
+        digest: ImageReference.Digest
+    ) async throws -> ImageConfiguration {
+        let data = try await getBlob(repository: image.repository, digest: digest)
+        return try decoder.decode(ImageConfiguration.self, from: data)
     }
 
     /// Upload an image configuration record to the registry.
@@ -35,9 +37,10 @@ extension RegistryClient {
     /// - Throws: If the blob upload fails.
     ///
     /// Image configuration records are stored as blobs in the registry.  This function encodes the provided configuration record and stores it as a blob in the registry.
-    public func putImageConfiguration(forImage image: ImageReference, configuration: ImageConfiguration) async throws
-        -> ContentDescriptor
-    {
+    public func putImageConfiguration(
+        forImage image: ImageReference,
+        configuration: ImageConfiguration
+    ) async throws -> ContentDescriptor {
         try await putBlob(
             repository: image.repository,
             mediaType: "application/vnd.oci.image.config.v1+json",

--- a/Sources/ContainerRegistry/RegistryClient.swift
+++ b/Sources/ContainerRegistry/RegistryClient.swift
@@ -308,27 +308,6 @@ extension RegistryClient {
         }
     }
 
-    /// Execute an HTTP request with no request body, decoding the JSON response
-    /// - Parameters:
-    ///   - request: The HTTP request to execute.
-    ///   - success: The HTTP status code expected if the request is successful.
-    ///   - errors: Expected error codes for which the registry sends structured error messages.
-    /// - Returns: An asynchronously-delivered tuple that contains the raw response body as a Data instance, and a HTTPURLResponse.
-    /// - Throws: If the server response is unexpected or indicates that an error occurred.
-    func executeRequestThrowing<Response: Decodable>(
-        _ request: RegistryOperation,
-        expectingStatus success: HTTPResponse.Status = .ok,
-        decodingErrors errors: [HTTPResponse.Status]
-    ) async throws -> (data: Response, response: HTTPResponse) {
-        let (data, httpResponse) = try await executeRequestThrowing(
-            request,
-            expectingStatus: success,
-            decodingErrors: errors
-        )
-        let decoded = try decoder.decode(Response.self, from: data)
-        return (decoded, httpResponse)
-    }
-
     /// Execute an HTTP request uploading a request body.
     /// - Parameters:
     ///   - operation: The Registry operation to execute.
@@ -337,9 +316,6 @@ extension RegistryClient {
     ///   - errors: Expected error codes for which the registry sends structured error messages.
     /// - Returns: An asynchronously-delivered tuple that contains the raw response body as a Data instance, and a HTTPURLResponse.
     /// - Throws: If the server response is unexpected or indicates that an error occurred.
-    ///
-    /// A plain Data version of this function is required because Data is Encodable and encodes to base64.
-    /// Accidentally encoding data blobs will cause digests to fail and runtimes to be unable to run the images.
     func executeRequestThrowing(
         _ operation: RegistryOperation,
         uploading payload: Data,

--- a/Sources/ContainerRegistry/Tags.swift
+++ b/Sources/ContainerRegistry/Tags.swift
@@ -15,6 +15,10 @@
 public extension RegistryClient {
     func getTags(repository: ImageReference.Repository) async throws -> Tags {
         // See https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-tags
-        try await executeRequestThrowing(.get(repository, path: "tags/list"), decodingErrors: [.notFound]).data
+        let (data, _) = try await executeRequestThrowing(
+            .get(repository, path: "tags/list"),
+            decodingErrors: [.notFound]
+        )
+        return try decoder.decode(Tags.self, from: data)
     }
 }


### PR DESCRIPTION
Motivation
----------

Return type overloads can be puzzling for new readers because the same function call returns a different type depending on where it is called.  In some cases a type annotation is needed at the call site, but when the overloaded function is the final call in another function the compiler can infer the type, so the reader needs to know to check the type of the enclosing function.

In addition, in a future pull request we will need access to the underlying data returned by the HTTP client, in order to verify digests and create `ContentDescriptor` objects.  This refactoring starts to prepare for that and makes the code easier to understand.

Modifications
-------------

* Remove return-type overloaded version of `executeRequestThrowing()`
* Remove return-type overloaded version of `getBlob()`

Result
------

Refactoring.   No functional change.

Test Plan
---------

Existing tests continue to pass.