### PR TITLE
Update Package.swift

### DIFF
--- a/Examples/HelloWorldHummingbird/Package.swift
+++ b/Examples/HelloWorldHummingbird/Package.swift
@@ -21,7 +21,6 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.1.0"),
-        .package(path: "../.."),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
     ],
     targets: [


### PR DESCRIPTION
Motivation
----------

I _believe_ the line `.package(path: "../.."),` in the `Package.swift` of the Hummingbird example is vestigial from perhaps a previous version where it was just a `Package.swift` and a `main.swift`.  If it is need explicitly for a container build, please mention in the docs because a regular `swift build` to test the app locally doesn't work until it is removed. 

Modifications
-------------

removed the single line `.package(path: "../..")` from the `Package.swift` in the Hummingbird example.

Result
------

Example will now build to be tested pre-containerization test. 

Test Plan
---------

Don't believe change needs a test as the example already does not have tests. 
