### PR TITLE
Set the default arguments passed to the entrypoint

### DIFF
--- a/Plugins/ContainerImageBuilder/main.swift
+++ b/Plugins/ContainerImageBuilder/main.swift
@@ -99,8 +99,8 @@ extension PluginError: CustomStringConvertible {
         let helperURL = try context.tool(named: "containertool").url
         let helperArgs =
             (FileManager.default.fileExists(atPath: resources.path) ? ["--resources", resources.path] : [])
-            + extractor.remainingArguments
             + builtExecutables.map { $0.url.path }
+            + extractor.remainingArguments
         let helperEnv = ProcessInfo.processInfo.environment.filter { $0.key.starts(with: "CONTAINERTOOL_") }
 
         let err = Pipe()

--- a/Sources/containertool/Extensions/RegistryClient+publish.swift
+++ b/Sources/containertool/Extensions/RegistryClient+publish.swift
@@ -25,6 +25,7 @@ func publishContainerImage<Source: ImageSource, Destination: ImageDestination>(
     destination: Destination,
     architecture: String,
     os: String,
+    cmd: [String],
     resources: [String],
     tag: String?,
     verbose: Bool,
@@ -80,7 +81,7 @@ func publishContainerImage<Source: ImageSource, Destination: ImageDestination>(
     // and override the entrypoint.
     var inheritedConfiguration = baseImageConfiguration.config ?? .init()
     inheritedConfiguration.Entrypoint = ["/\(executableURL.lastPathComponent)"]
-    inheritedConfiguration.Cmd = []
+    inheritedConfiguration.Cmd = cmd
     inheritedConfiguration.WorkingDir = "/"
 
     let configuration = ImageConfiguration(

--- a/Sources/containertool/containertool.swift
+++ b/Sources/containertool/containertool.swift
@@ -64,6 +64,9 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
 
         @Option(help: "Operating system")
         var os: String?
+
+        @Option(parsing: .remaining, help: "Default arguments to pass to the entrypoint process")
+        var cmd: [String] = []
     }
 
     @OptionGroup(title: "Image configuration options")
@@ -222,6 +225,7 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
             destination: destination,
             architecture: architecture,
             os: os,
+            cmd: imageConfigurationOptions.cmd,
             resources: imageBuildOptions.resources,
             tag: repositoryOptions.tag,
             verbose: verbose,

--- a/Sources/swift-container-plugin/Documentation.docc/build-container-image.md
+++ b/Sources/swift-container-plugin/Documentation.docc/build-container-image.md
@@ -56,6 +56,10 @@ Wrap a binary in a container image and publish it.
 - term  `--os <os>`:
   Operating system required to run the image. (default: `linux`)
 
+- term  `--cmd <cmd1> <cmd2> …`:
+  Default arguments to pass to the entrypoint process.
+  This MUST be the last option present as all following arguments are considered part of the CMD entry. 
+
 ### Authentication options
 
 - term  `--default-username <username>`:

--- a/scripts/test-containertool-cmd.sh
+++ b/scripts/test-containertool-cmd.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftContainerPlugin open source project
+##
+## Copyright (c) 2025 Apple Inc. and the SwiftContainerPlugin project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftContainerPlugin project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+#
+# This script assumes that the Static Linux SDK has already been installed
+#
+
+log() { printf -- "** %s\n" "$*" >&2; }
+error() { printf -- "** ERROR: %s\n" "$*" >&2; }
+fatal() { error "$@"; exit 1; }
+
+set -euo pipefail
+
+RUNTIME=${RUNTIME-"docker"}
+
+#
+# Create a test package
+#
+PKGPATH=$(mktemp -d)
+swift package --package-path "$PKGPATH" init --type executable --name hello
+
+cleanup() {
+  log "Deleting temporary package $PKGPATH"
+  rm -rf "$PKGPATH"
+}
+trap cleanup EXIT
+
+#
+# Build and package an aarch64 binary
+#
+swift build --package-path "$PKGPATH" --swift-sdk aarch64-swift-linux-musl
+
+IMGREF=$(swift run containertool --repository localhost:5000/elf_test "$PKGPATH/.build/aarch64-swift-linux-musl/debug/hello" --from scratch --cmd "arg1" "--option" "opt" "--flag")
+$RUNTIME pull "$IMGREF"
+CMD=$($RUNTIME inspect "$IMGREF" --format "{{.Config.Cmd}}")
+if [ "$CMD" = "[arg1 --option opt --flag]" ] ; then
+  log "cmd option: PASSED"
+else
+  fatal "cmd option: FAILED - cmd was $CMD; expected [arg1 --option opt --flag]"
+fi


### PR DESCRIPTION
Motivation
----------

Allow configuring the CMD entry of the generated image config.

Modifications
-------------

Added the argument parsing in containertool.swift and pass it to the publish method.
Given the CMD entries are often options themselves, the .remaining parsing strategy is used.
This means this option must be the last.
Also means that in ContainerImageBuilder/main.swift, the order has been altered when building the arguments used to call the containertool process.

Result
------

Can configure CMD entry, e.g. for a Vapor example

swift package --swift-sdk aarch64-swift-linux-musl build-container-image --repository localhost:5000/hello --cmd "serve" "--env" "production" "--hostname" "0.0.0.0" "--port" "8080"

Test Plan
---------

Added a test-containertool-cmd.sh script to perform some basic testing.
