### PR TITLE
ci: Add --skip flags for Swift 6.2 matrix job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
             linux_5_10_enabled: false
             linux_6_0_arguments_override: "--skip SmokeTests --skip TarInteropTests"
             linux_6_1_arguments_override: "--skip SmokeTests --skip TarInteropTests"
+            linux_6_2_arguments_override: "--skip SmokeTests --skip TarInteropTests"
             linux_nightly_6_1_arguments_override: "--skip SmokeTests --skip TarInteropTests"
             linux_nightly_main_arguments_override: "--skip SmokeTests --skip TarInteropTests"
 


### PR DESCRIPTION
Motivation
----------

Swift NIO's unit test matrix job has been [updated for Swift 6.2](https://github.com/apple/swift-nio/pull/3374), so additional override flags must be defined.

Modifications
-------------

Define `linux_6_2_arguments_override` for pull requests and the scheduled build on main.

Result
------

Tests with Swift 6.2 will pass.

Test Plan
---------

Existing tests pass again.