### PR TITLE
ci: Runner now uses Swift 6.2;  update the Static SDK to match

### DIFF
--- a/.github/workflows/endtoend_tests.yml
+++ b/.github/workflows/endtoend_tests.yml
@@ -35,8 +35,8 @@ jobs:
             - name: Install the static SDK
               run: |
                   swift sdk install \
-                      https://download.swift.org/swift-6.1-release/static-sdk/swift-6.1-RELEASE/swift-6.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz \
-                      --checksum 111c6f7d280a651208b8c74c0521dd99365d785c1976a6e23162f55f65379ac6
+                      https://download.swift.org/swift-6.2-release/static-sdk/swift-6.2-RELEASE/swift-6.2-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz \
+                      --checksum d2225840e592389ca517bbf71652f7003dbf45ac35d1e57d98b9250368769378
 
             - name: Build the example
               run: |

--- a/.github/workflows/interop_tests.yml
+++ b/.github/workflows/interop_tests.yml
@@ -61,8 +61,8 @@ jobs:
             - name: Install the static SDK
               run: |
                   swift sdk install \
-                      https://download.swift.org/swift-6.1-release/static-sdk/swift-6.1-RELEASE/swift-6.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz \
-                      --checksum 111c6f7d280a651208b8c74c0521dd99365d785c1976a6e23162f55f65379ac6
+                      https://download.swift.org/swift-6.2-release/static-sdk/swift-6.2-RELEASE/swift-6.2-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz \
+                      --checksum d2225840e592389ca517bbf71652f7003dbf45ac35d1e57d98b9250368769378
 
             # Run the test script
             - name: Test ELF detection


### PR DESCRIPTION
Motivation
----------

End to end and integration tests are failing because the underlying Swift CI runner has been updated to use Swift 6.2 but these tests install the 6.1 release of the Static Linux SDK.

Modifications
-------------

Update end to end and integration workflows to install the the 6.2 release of the Static Linux SDK.

Result
------

All tests will pass again.

Test Plan
---------

All existing tests pass again.