### PR TITLE
Update pull request workflow for 6.2

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,6 +23,7 @@ jobs:
             linux_5_10_enabled: false
             linux_6_0_arguments_override: "--skip SmokeTests --skip TarInteropTests"
             linux_6_1_arguments_override: "--skip SmokeTests --skip TarInteropTests"
+            linux_6_2_arguments_override: "--skip SmokeTests --skip TarInteropTests"
             linux_nightly_6_1_arguments_override: "--skip SmokeTests --skip TarInteropTests"
             linux_nightly_main_arguments_override: "--skip SmokeTests --skip TarInteropTests"
 


### PR DESCRIPTION
Motivation
----------

#158 added Swift 6.2 flags to the `main` workflow, but the `pull_request` workflow has a separate list of flags which was not updated.

Modifications
-------------

Update `pull_request` workflow to match `main`.

Result
------

Correct 6.2 flags will be applied to pull request workflow runs.

Test Plan
---------

This PR will fail because the integration and end-to-end tests does still install the 6.1 Static SDK.