### PR TITLE
Update swift-crypto dependency range

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .plugin(name: "ContainerImageBuilder", targets: ["ContainerImageBuilder"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"4.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"5.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-http-types.git", from: "1.2.0"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),


### PR DESCRIPTION
Motivation
----------

Swift Crypto doesn't change its public API much between major releases and recommends to use a range from "1.0.0" ..< "5.0.0"

Modifications
-------------

Update the dependency range to "1.0.0" ..< "5.0.0" as swift-crypto recommends

Result
------

Projects can use the latest swift-crypto
