### PR TITLE
ci: Runner now uses Swift 6.3;  update the Static SDK to match

### DIFF
--- a/.github/workflows/endtoend_tests.yml
+++ b/.github/workflows/endtoend_tests.yml
@@ -41,8 +41,8 @@ jobs:
             - name: Install the static SDK
               run: |
                   swift sdk install \
-                      https://download.swift.org/swift-6.2.3-release/static-sdk/swift-6.2.3-RELEASE/swift-6.2.3-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz \
-                      --checksum f30ec724d824ef43b5546e02ca06a8682dafab4b26a99fbb0e858c347e507a2c
+                      https://download.swift.org/swift-6.3-release/static-sdk/swift-6.3-RELEASE/swift-6.3-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz \
+                      --checksum d2078b69bdeb5c31202c10e9d8a11d6f66f82938b51a4b75f032ccb35c4c286c
 
             - name: Build the example
               run: |

--- a/.github/workflows/interop_tests.yml
+++ b/.github/workflows/interop_tests.yml
@@ -64,8 +64,8 @@ jobs:
             - name: Install the static SDK
               run: |
                   swift sdk install \
-                      https://download.swift.org/swift-6.2.3-release/static-sdk/swift-6.2.3-RELEASE/swift-6.2.3-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz \
-                      --checksum f30ec724d824ef43b5546e02ca06a8682dafab4b26a99fbb0e858c347e507a2c
+                      https://download.swift.org/swift-6.3-release/static-sdk/swift-6.3-RELEASE/swift-6.3-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz \
+                      --checksum d2078b69bdeb5c31202c10e9d8a11d6f66f82938b51a4b75f032ccb35c4c286c
 
             # Run the test script
             - name: Test ELF detection

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
             linux_6_0_arguments_override: "--skip SmokeTests --skip TarInteropTests"
             linux_6_1_arguments_override: "--skip SmokeTests --skip TarInteropTests"
             linux_6_2_arguments_override: "--skip SmokeTests --skip TarInteropTests"
+            linux_6_3_arguments_override: "--skip SmokeTests --skip TarInteropTests"
             linux_nightly_6_1_arguments_override: "--skip SmokeTests --skip TarInteropTests"
             linux_nightly_main_arguments_override: "--skip SmokeTests --skip TarInteropTests"
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,6 +27,7 @@ jobs:
             linux_6_0_arguments_override: "--skip SmokeTests --skip TarInteropTests"
             linux_6_1_arguments_override: "--skip SmokeTests --skip TarInteropTests"
             linux_6_2_arguments_override: "--skip SmokeTests --skip TarInteropTests"
+            linux_6_3_arguments_override: "--skip SmokeTests --skip TarInteropTests"
             linux_nightly_6_1_arguments_override: "--skip SmokeTests --skip TarInteropTests"
             linux_nightly_main_arguments_override: "--skip SmokeTests --skip TarInteropTests"
 


### PR DESCRIPTION
Motivation
----------

End to end and integration tests are failing because the underlying Swift CI runner has been updated to use Swift 6.3 but these tests install the 6.2.3 release of the Static Linux SDK.

Modifications
-------------

Update end to end and integration workflows to install the the 6.3 release of the Static Linux SDK.

Result
------

All tests will pass again.

Test Plan
---------

All existing tests pass again.