### PR TITLE
ci: Runner now uses Swift 6.3.1;  update the Static SDK to match

### DIFF
--- a/.github/workflows/endtoend_tests.yml
+++ b/.github/workflows/endtoend_tests.yml
@@ -41,8 +41,8 @@ jobs:
             - name: Install the static SDK
               run: |
                   swift sdk install \
-                      https://download.swift.org/swift-6.3-release/static-sdk/swift-6.3-RELEASE/swift-6.3-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz \
-                      --checksum d2078b69bdeb5c31202c10e9d8a11d6f66f82938b51a4b75f032ccb35c4c286c
+                      https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz \
+                      --checksum 3fd798bef6f4408f1ea5a6f94ce4d4052830c4326ab85ebc04f983f01b3da407
 
             - name: Build the example
               run: |

--- a/.github/workflows/interop_tests.yml
+++ b/.github/workflows/interop_tests.yml
@@ -64,8 +64,8 @@ jobs:
             - name: Install the static SDK
               run: |
                   swift sdk install \
-                      https://download.swift.org/swift-6.3-release/static-sdk/swift-6.3-RELEASE/swift-6.3-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz \
-                      --checksum d2078b69bdeb5c31202c10e9d8a11d6f66f82938b51a4b75f032ccb35c4c286c
+                      https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz \
+                      --checksum 3fd798bef6f4408f1ea5a6f94ce4d4052830c4326ab85ebc04f983f01b3da407
 
             # Run the test script
             - name: Test ELF detection


### PR DESCRIPTION
Motivation
----------

End to end and integration tests are failing because the underlying Swift CI runner has been updated to use Swift 6.3.1 but these tests install the 6.3.0 release of the Static Linux SDK.

Modifications
-------------

Update end to end and integration workflows to install the the 6.3.2 release of the Static Linux SDK.

Result
------

All tests will pass again.

Test Plan
---------

All existing tests pass again.