### PR TITLE
Add request context to HTTPClientError.unexpectedStatusCode and CustomStringConvertible conformance

### DIFF
--- a/Sources/ContainerRegistry/HTTPClient.swift
+++ b/Sources/ContainerRegistry/HTTPClient.swift
@@ -23,7 +23,7 @@ import HTTPTypesFoundation
 ///
 /// The response to a `HEAD` request does not include a body so if an error is thrown, `data` will be `nil`
 public enum HTTPClientError: Error {
-    case unexpectedStatusCode(status: HTTPResponse.Status, response: HTTPResponse, data: Data?)
+    case unexpectedStatusCode(request: HTTPRequest, status: HTTPResponse.Status, response: HTTPResponse, data: Data?)
     case unexpectedContentType(String)
     case missingContentType
     case missingResponseHeader(String)
@@ -85,9 +85,9 @@ extension URLSession: HTTPClient {
 
             // A HEAD request has no response body and cannot be decoded
             if request.method == .head {
-                throw HTTPClientError.unexpectedStatusCode(status: response.status, response: response, data: nil)
+                throw HTTPClientError.unexpectedStatusCode(request: request, status: response.status, response: response, data: nil)
             }
-            throw HTTPClientError.unexpectedStatusCode(status: response.status, response: response, data: responseData)
+            throw HTTPClientError.unexpectedStatusCode(request: request, status: response.status, response: response, data: responseData)
         }
 
         return response
@@ -132,6 +132,32 @@ extension URLSession: HTTPClient {
             expectingStatus: success
         )
         return (responseData, httpResponse)
+    }
+}
+
+extension HTTPClientError: CustomStringConvertible {
+    /// Human-readable description of an HTTPClientError, including the registry hostname where available.
+    public var description: String {
+        switch self {
+        case let .unexpectedStatusCode(request, status, _, _):
+            let host = request.url?.host ?? "unknown registry"
+            if status == .unauthorized || status == .forbidden {
+                return "Authentication failed for registry \"\(host)\": the server returned HTTP \(status.code). Ensure your credentials are correct."
+            }
+            return "Registry \"\(host)\" returned an unexpected HTTP \(status.code) response."
+        case let .unexpectedContentType(type):
+            return "Unexpected content type: \(type)"
+        case .missingContentType:
+            return "Response is missing a content type"
+        case let .missingResponseHeader(header):
+            return "Response is missing the '\(header)' header"
+        case let .authenticationChallenge(_, request, _):
+            let host = request.url?.host ?? "unknown registry"
+            return "Registry \"\(host)\" requires authentication."
+        case let .unauthorized(request, _):
+            let host = request.url?.host ?? "unknown registry"
+            return "Authentication failed for registry \"\(host)\": credentials were rejected."
+        }
     }
 }
 

--- a/Sources/ContainerRegistry/RegistryClient.swift
+++ b/Sources/ContainerRegistry/RegistryClient.swift
@@ -369,7 +369,7 @@ extension RegistryClient {
 
         do {
             return try await client.executeRequestThrowing(request, expectingStatus: success)
-        } catch HTTPClientError.unexpectedStatusCode(let status, _, let .some(responseData))
+        } catch HTTPClientError.unexpectedStatusCode(_, let status, _, let .some(responseData))
             where errors.contains(status)
         {
             // Try to decode as JSON; if that fails, throw a generic error with the raw response body
@@ -416,7 +416,7 @@ extension RegistryClient {
 
         do {
             return try await client.executeRequestThrowing(request, uploading: payload, expectingStatus: success)
-        } catch HTTPClientError.unexpectedStatusCode(let status, _, let .some(responseData))
+        } catch HTTPClientError.unexpectedStatusCode(_, let status, _, let .some(responseData))
             where errors.contains(status)
         {
             // Try to decode as JSON; if that fails, throw a generic error with the raw response body


### PR DESCRIPTION
Closes #118

## What

Two related changes to `HTTPClientError`:

1. **Adds the originating `HTTPRequest` to the `unexpectedStatusCode` case.** The other two error cases that involve a remote server (`unauthorized`, `authenticationChallenge`) already carry the request so callers can surface the registry hostname in diagnostics. `unexpectedStatusCode` was the odd one out.

2. **Adds `CustomStringConvertible` conformance.** The implementation uses the new `request` field to produce user-readable messages that include the registry hostname and a tailored explanation for 401/403 responses, for example:

   ```
   Authentication failed for registry "ghcr.io": the server returned HTTP 401. Ensure your credentials are correct.
   Registry "ghcr.io" returned an unexpected HTTP 404 response.
   ```

I noticed the inconsistency while reading through the error type — `unauthorized` and `authenticationChallenge` both thread the request through so their error messages can mention the host, but `unexpectedStatusCode` dropped it on the floor. This meant the most common error case (any non-2xx response) produced the least informative message.

## Changes

- `Sources/ContainerRegistry/HTTPClient.swift`: adds `request: HTTPRequest` as the first label on `unexpectedStatusCode`, threads the request through both throw sites in `validateAPIResponseThrowing`, and adds the `CustomStringConvertible` extension.
- `Sources/ContainerRegistry/RegistryClient.swift`: updates the two `catch` clauses that pattern-match on `unexpectedStatusCode` to bind a wildcard for the new leading `request` parameter.