### PR TITLE
Honour SOURCE_DATE_EPOCH for reproducible builds

### DIFF
--- a/Plugins/ContainerImageBuilder/main.swift
+++ b/Plugins/ContainerImageBuilder/main.swift
@@ -115,7 +115,9 @@ extension PluginError: CustomStringConvertible {
             resources.map { "--resources=\($0)" }
             + builtExecutables.map { $0.url.path }
             + extractor.remainingArguments
-        let helperEnv = ProcessInfo.processInfo.environment.filter { $0.key.starts(with: "CONTAINERTOOL_") }
+        let helperEnv = ProcessInfo.processInfo.environment.filter {
+                        $0.key.starts(with: "CONTAINERTOOL_") || $0.key == "SOURCE_DATE_EPOCH"
+        }
 
         let err = Pipe()
 

--- a/Sources/Tar/tar.swift
+++ b/Sources/Tar/tar.swift
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftContainerPlugin open source project
+// This source file is part of the SwiftCntainerPlugin open source project
 //
 // Copyright (c) 2024 Apple Inc. and the SwiftContainerPlugin project authors
 // Licensed under Apache License v2.0
@@ -432,8 +432,8 @@ extension Archive {
     /// - name: File name
     /// - prefix: Path prefix
     /// - data: File contents
-    public mutating func appendFile(name: String, prefix: String = "", data: [UInt8]) throws {
-        try append(.init(header: .init(name: name, size: data.count, prefix: prefix), data: data))
+    public mutating func appendFile(name: String, prefix: String = "", data: [UInt8], mtime: Int = 0) throws {
+        try append(.init(header: .init(name: name, size: data.count, prefix: prefix, mtime: mtime), data: data))
     }
 
     /// Adds a new file member at the end of the archive
@@ -441,23 +441,23 @@ extension Archive {
     /// - name: File name
     /// - prefix: Path prefix
     /// - data: File contents
-    public func appendingFile(name: String, prefix: String = "", data: [UInt8]) throws -> Self {
-        try appending(.init(header: .init(name: name, size: data.count, prefix: prefix), data: data))
+    public func appendingFile(name: String, prefix: String = "", data: [UInt8], mtime: Int = 0) throws -> Self {
+        try appending(.init(header: .init(name: name, size: data.count, prefix: prefix, mtime: mtime), data: data))
     }
 
     /// Adds a new directory member at the end of the archive
     /// parameters:
     /// - name: Directory name
     /// - prefix: Path prefix
-    public mutating func appendDirectory(name: String, prefix: String = "") throws {
-        try append(.init(header: .init(name: name, typeflag: .DIRTYPE, prefix: prefix)))
+    public mutating func appendDirectory(name: String, prefix: String = "", mtime: Int = 0) throws {
+        try append(.init(header: .init(name: name, typeflag: .DIRTYPE, prefix: prefix, mtime: mtime)))
     }
 
     /// Adds a new directory member at the end of the archive
     /// parameters:
     /// - name: Directory name
     /// - prefix: Path prefix
-    public func appendingDirectory(name: String, prefix: String = "") throws -> Self {
-        try self.appending(.init(header: .init(name: name, typeflag: .DIRTYPE, prefix: prefix)))
+    public func appendingDirectory(name: String, prefix: String = "", mtime: Int = 0) throws -> Self {
+        try self.appending(.init(header: .init(name: name, typeflag: .DIRTYPE, prefix: prefix, mtime: mtime)))
     }
 }

--- a/Sources/Tar/tar.swift
+++ b/Sources/Tar/tar.swift
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftCntainerPlugin open source project
+// This source file is part of the SwiftContainerPlugin open source project
 //
 // Copyright (c) 2024 Apple Inc. and the SwiftContainerPlugin project authors
 // Licensed under Apache License v2.0

--- a/Sources/containertool/Extensions/Archive+appending.swift
+++ b/Sources/containertool/Extensions/Archive+appending.swift
@@ -20,80 +20,83 @@ import struct Foundation.URL
 import Tar
 
 extension URL {
-    var isDirectory: Bool {
-        (try? resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
-    }
+        var isDirectory: Bool {
+                    (try? resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+        }
 }
 
 extension Archive {
-    /// Append a file or directory tree to the archive.   Directory trees are appended recursively.
-    /// Parameters:
-    /// - root: The path to the file or directory to add.
-    /// Returns:  A new archive made by appending `root` to the receiver.
-    public func appendingRecursively(atPath root: String) throws -> Self {
-        let url = URL(fileURLWithPath: root)
-        if url.isDirectory {
-            return try self.appendingDirectoryTree(at: url)
-        } else {
-            return try self.appendingFile(at: url)
-        }
-    }
-
-    /// Append a single file to the archive.
-    /// Parameters:
-    /// - path: The path to the file to add.
-    /// Returns:  A new archive made by appending `path` to the receiver.
-    func appendingFile(at path: URL) throws -> Self {
-        try self.appendingFile(name: path.lastPathComponent, data: try [UInt8](Data(contentsOf: path)))
-    }
-
-    func appendingFile(at path: URL, to destinationPath: URL) throws -> Self {
-        var ret = self
-        let data = try [UInt8](Data(contentsOf: path))
-        let components = destinationPath.pathComponents
-        precondition(!components.isEmpty, "Destination path is empty")
-        for i in 1..<components.count - 1 {
-            let directoryPath = components[..<i].joined(separator: "/")
-            try ret.appendDirectory(name: directoryPath)
+        /// Append a file or directory tree to the archive.   Directory trees are appended recursively.
+        /// Parameters:
+        /// - root: The path to the file or directory to add.
+        /// - mtime: Modification time for all entries as seconds since the Unix epoch (default: 0).
+        /// Returns:  A new archive made by appending `root` to the receiver.
+        public func appendingRecursively(atPath root: String, mtime: Int = 0) throws -> Self {
+                    let url = URL(fileURLWithPath: root)
+                    if url.isDirectory {
+                                    return try self.appendingDirectoryTree(at: url, mtime: mtime)
+                    } else {
+                                    return try self.appendingFile(at: url, mtime: mtime)
+                    }
         }
 
-        try ret.appendFile(name: destinationPath.path(), data: data)
-        return ret
-    }
-
-    /// Recursively append a single directory tree to the archive.
-    /// Parameters:
-    /// - root: The path to the directory to add.
-    /// Returns:  A new archive made by appending `root` to the receiver.
-    func appendingDirectoryTree(at root: URL, to destinationPath: URL = URL(filePath: "/")) throws -> Self {
-        var ret = self
-
-        guard let enumerator = FileManager.default.enumerator(atPath: root.path) else {
-            throw ("Unable to read \(root.path)")
+        /// Append a single file to the archive.
+        /// Parameters:
+        /// - path: The path to the file to add.
+        /// - mtime: Modification time as seconds since the Unix epoch (default: 0).
+        /// Returns:  A new archive made by appending `path` to the receiver.
+        func appendingFile(at path: URL, mtime: Int = 0) throws -> Self {
+                    try self.appendingFile(name: path.lastPathComponent, data: try [UInt8](Data(contentsOf: path)), mtime: mtime)
         }
 
-        for case let subpath as String in enumerator {
-            // https://developer.apple.com/documentation/foundation/filemanager/1410452-attributesofitem
-            // https://developer.apple.com/documentation/foundation/fileattributekey
+        func appendingFile(at path: URL, to destinationPath: URL, mtime: Int = 0) throws -> Self {
+                    var ret = self
+                    let data = try [UInt8](Data(contentsOf: path))
+                    let components = destinationPath.pathComponents
+                    precondition(!components.isEmpty, "Destination path is empty")
+                    for i in 1..<components.count - 1 {
+                                    let directoryPath = components[..<i].joined(separator: "/")
+                                    try ret.appendDirectory(name: directoryPath, mtime: mtime)
+                    }
 
-            guard let filetype = enumerator.fileAttributes?[.type] as? FileAttributeType else {
-                throw ("Unable to get file type for \(subpath)")
-            }
-
-            let subpath = destinationPath.appending(path: subpath).path()
-            switch filetype {
-            case .typeRegular:
-                let resource = try [UInt8](Data(contentsOf: root.appending(path: subpath)))
-                try ret.appendFile(name: subpath, prefix: root.lastPathComponent, data: resource)
-
-            case .typeDirectory:
-                try ret.appendDirectory(name: subpath, prefix: root.lastPathComponent)
-
-            default:
-                throw "Resource file \(subpath) of type \(filetype) is not supported"
-            }
+                    try ret.appendFile(name: destinationPath.path(), data: data, mtime: mtime)
+                    return ret
         }
 
-        return ret
-    }
+        /// Recursively append a single directory tree to the archive.
+        /// Parameters:
+        /// - root: The path to the directory to add.
+        /// - mtime: Modification time for all entries as seconds since the Unix epoch (default: 0).
+        /// Returns:  A new archive made by appending `root` to the receiver.
+        func appendingDirectoryTree(at root: URL, to destinationPath: URL = URL(filePath: "/"), mtime: Int = 0) throws -> Self {
+                    var ret = self
+
+                    guard let enumerator = FileManager.default.enumerator(atPath: root.path) else {
+                                    throw ("Unable to read \(root.path)")
+                    }
+
+                    for case let subpath as String in enumerator {
+                                    // https://developer.apple.com/documentation/foundation/filemanager/1410452-attributesofitem
+                                    // https://developer.apple.com/documentation/foundation/fileattributekey
+
+                                    guard let filetype = enumerator.fileAttributes?[.type] as? FileAttributeType else {
+                                                        throw ("Unable to get file type for \(subpath)")
+                                    }
+
+                                    let subpath = destinationPath.appending(path: subpath).path()
+                                    switch filetype {
+                                                    case .typeRegular:
+                                                        let resource = try [UInt8](Data(contentsOf: root.appending(path: subpath)))
+                                                        try ret.appendFile(name: subpath, prefix: root.lastPathComponent, data: resource, mtime: mtime)
+
+                                                    case .typeDirectory:
+                                                        try ret.appendDirectory(name: subpath, prefix: root.lastPathComponent, mtime: mtime)
+
+                                                    default:
+                                                        throw "Resource file \(subpath) of type \(filetype) is not supported"
+                                    }
+                    }
+
+                    return ret
+        }
 }

--- a/Sources/containertool/Extensions/RegistryClient+publish.swift
+++ b/Sources/containertool/Extensions/RegistryClient+publish.swift
@@ -14,6 +14,7 @@
 
 import class Foundation.FileManager
 import struct Foundation.ObjCBool
+import class Foundation.ProcessInfo
 import struct Foundation.Date
 import struct Foundation.URL
 
@@ -50,6 +51,14 @@ func publishContainerImage<Source: ImageSource, Destination: ImageDestination>(
     )
     log("Found base image configuration: \(baseImageManifest.config.digest)")
 
+        // Honour SOURCE_DATE_EPOCH for reproducible builds if set.
+        let sourceEpoch: Int
+        if let epochStr = ProcessInfo.processInfo.environment["SOURCE_DATE_EPOCH"],
+           let epochValue = Int(epochStr) {
+                       sourceEpoch = epochValue
+           } else {
+                       sourceEpoch = 0
+           }
     // MARK: Upload resource layers
 
     var resourceLayers: [(descriptor: ContentDescriptor, diffID: ImageReference.Digest)] = []
@@ -57,7 +66,7 @@ func publishContainerImage<Source: ImageSource, Destination: ImageDestination>(
         let paths = resourceDir.split(separator: ":", maxSplits: 1)
         switch paths.count {
         case 1:
-            let resourceTardiff = try Archive().appendingRecursively(atPath: resourceDir).bytes
+            let resourceTardiff = try Archive().appendingRecursively(atPath: resourceDir, mtime: sourceEpoch).bytes
             let resourceLayer = try await destination.uploadLayer(
                 repository: destinationImage.repository,
                 contents: resourceTardiff
@@ -85,7 +94,8 @@ func publishContainerImage<Source: ImageSource, Destination: ImageDestination>(
                 archive = try Archive()
                     .appendingFile(
                         at: URL(fileURLWithPath: String(sourcePath)),
-                        to: URL(fileURLWithPath: String(destinationPath))
+                        to: URL(fileURLWithPath: String(destinationPath)),
+                        mtime: sourceEpoch
                     )
             }
 
@@ -108,7 +118,7 @@ func publishContainerImage<Source: ImageSource, Destination: ImageDestination>(
 
     let applicationLayer = try await destination.uploadLayer(
         repository: destinationImage.repository,
-        contents: try Archive().appendingFile(at: executableURL).bytes
+        contents: try Archive().appendingFile(at: executableURL, mtime: sourceEpoch).bytes
     )
     if verbose {
         log("application layer: \(applicationLayer.descriptor.digest) (\(applicationLayer.descriptor.size) bytes)")
@@ -116,7 +126,7 @@ func publishContainerImage<Source: ImageSource, Destination: ImageDestination>(
 
     // MARK: Create the application configuration
 
-    let timestamp = Date(timeIntervalSince1970: 0).ISO8601Format()
+    let timestamp = Date(timeIntervalSince1970: TimeInterval(sourceEpoch)).ISO8601Format()
 
     // Inherit the configuration of the base image - UID, GID, environment etc -
     // and override the entrypoint.


### PR DESCRIPTION
Motivation
----------

I was trying to build a reproducible OCI image - same source, same digest every time - and noticed that containertool always writes 0 as the tar entry mtime and `Date(timeIntervalSince1970: 0)` as the image creation timestamp, regardless of any environment variables. The [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/) convention is the standard way to communicate a canonical build time to tools like this, and issue #41 tracks exactly this gap.

Because tar entry mtimes feed into layer digest computation and the image timestamp is baked into the image config digest, both need to use the same epoch value for the build to be truly reproducible.

Modifications
-------------

- Added an `mtime: Int = 0` parameter (defaulting to 0, so existing behaviour is unchanged) to `Archive.appendFile`, `Archive.appendDirectory`, `Archive.appendingFile`, `Archive.appendingDirectory`, and all the recursive helpers in `Archive+appending.swift`.
- - In `RegistryClient+publish.swift`, read `SOURCE_DATE_EPOCH` from the environment once at the start of the publish call and thread it through to all `Archive` calls and the image config timestamp.
- - In `Plugins/ContainerImageBuilder/main.swift`, extend the env-var filter (which already allowlists `CONTAINERTOOL_`-prefixed vars) to also forward `SOURCE_DATE_EPOCH` to the `containertool` subprocess.
Result
------

When `SOURCE_DATE_EPOCH` is set, containertool uses that value for all tar entry mtimes and the image creation timestamp, making layer and config digests deterministic across builds from the same source. When the variable is absent, behaviour is identical to before (mtime = 0, Unix epoch timestamp).

Test Plan
---------

```
export SOURCE_DATE_EPOCH=1234567890
swift package --disable-sandbox plugin containertool --repository <registry>/<name> ...
# build twice from the same source - verify both runs produce identical image digests
```