### PR TITLE
containertool: add --expose and --label flags

### DIFF
--- a/Sources/containertool/Extensions/RegistryClient+publish.swift
+++ b/Sources/containertool/Extensions/RegistryClient+publish.swift
@@ -30,6 +30,8 @@ func publishContainerImage<Source: ImageSource, Destination: ImageDestination>(
     entrypoint: String?,
     cmd: [String],
     additionalEnv: [String],
+    exposedPorts: [String],
+    labels: [String: String],
     resources: [String],
     tag: String?,
     verbose: Bool,
@@ -134,6 +136,22 @@ func publishContainerImage<Source: ImageSource, Destination: ImageDestination>(
         inheritedConfiguration.Env = env
     } else {
         inheritedConfiguration.Env = additionalEnv
+    }
+
+    if !exposedPorts.isEmpty {
+        var ports = inheritedConfiguration.ExposedPorts ?? [:]
+        for port in exposedPorts {
+            // Normalise: bare numbers get the default /tcp suffix.
+            let key = port.contains("/") ? port : "\(port)/tcp"
+            ports[key] = EmptyObject()
+        }
+        inheritedConfiguration.ExposedPorts = ports
+    }
+
+    if !labels.isEmpty {
+        var existingLabels = inheritedConfiguration.Labels ?? [:]
+        existingLabels.merge(labels) { _, new in new }
+        inheritedConfiguration.Labels = existingLabels
     }
 
     let configuration = ImageConfiguration(

--- a/Sources/containertool/containertool.swift
+++ b/Sources/containertool/containertool.swift
@@ -73,6 +73,34 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
 
         @Option(parsing: .remaining, help: "Default arguments to pass to the entrypoint process")
         var cmd: [String] = []
+
+        @Option(
+            parsing: .singleValue,
+            help: ArgumentHelp(
+                "Network port to expose at runtime (e.g. 80, 8080/tcp, 53/udp). Repeatable.",
+                valueName: "port"
+            )
+        )
+        var expose: [String] = []
+
+        @Option(
+            parsing: .singleValue,
+            help: ArgumentHelp(
+                "Label to apply to the image in key=value format. Repeatable.",
+                valueName: "key=value"
+            )
+        )
+        var label: [String] = []
+
+        mutating func validate() throws {
+            for entry in label {
+                guard entry.contains("=") else {
+                    throw ValidationError(
+                        "Invalid --label value '\(entry)': expected key=value format"
+                    )
+                }
+            }
+        }
     }
 
     @OptionGroup(title: "Image configuration options")
@@ -222,6 +250,14 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
         if verbose { log("Connected to destination registry: \(destinationImage.registry)") }
         if verbose { log("Using base image: \(baseImage)") }
 
+        // Parse --label key=value pairs into a dictionary.
+        var parsedLabels: [String: String] = [:]
+        for entry in imageConfigurationOptions.label {
+            // validate() guarantees every entry contains "="; split on first occurrence only.
+            let parts = entry.split(separator: "=", maxSplits: 1)
+            parsedLabels[String(parts[0])] = String(parts[1])
+        }
+
         // MARK: Build the image
 
         let finalImage = try await publishContainerImage(
@@ -234,6 +270,8 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
             entrypoint: imageConfigurationOptions.entrypoint,
             cmd: imageConfigurationOptions.cmd,
             additionalEnv: imageConfigurationOptions.env,
+            exposedPorts: imageConfigurationOptions.expose,
+            labels: parsedLabels,
             resources: imageBuildOptions.resources,
             tag: repositoryOptions.tag,
             verbose: verbose,


### PR DESCRIPTION
Closes #88
Closes #90

Adds two new CLI flags to `containertool`, addressing the feature requests in the parent issue #91.

### `--expose <port>`

Marks a network port as exposed in the image's OCI configuration. The flag can be repeated. Bare numbers are normalised to the default `/tcp` suffix (`--expose 8080` -> `8080/tcp`); explicit protocol suffixes are preserved as-is (`8080/tcp`, `53/udp`). New entries are merged with any ports already present in the base image.

### `--label <key=value>`

Applies an OCI image label. Like `--expose`, repeatable. Labels are merged with any already set by the base image; a `--label` value wins on key collision. Entries that don't contain `=` are rejected at validation time with a clear error.

Both flags follow the pattern established by `--env`: declared in `ImageConfigurationOptions` with `parsing: .singleValue`, passed as typed parameters to `publishContainerImage`, and merged into `inheritedConfiguration` before the `ImageConfiguration` is assembled.

I noticed these two issues while going through the open issue list after submitting #175. The OCI config schema already had `ExposedPorts` and `Labels` fields in `Schema.swift` - it was just a matter of wiring up the CLI surface and the merging logic.