### PR TITLE
e2e tests: run with podman as well as docker

### DIFF
--- a/.github/workflows/endtoend_tests.yml
+++ b/.github/workflows/endtoend_tests.yml
@@ -28,6 +28,9 @@ jobs:
                     - Examples/HelloWorldVapor
                     - Examples/HelloWorldHummingbird
                     - Examples/HelloWorldWithResources
+                runtime:
+                    - docker
+                    - podman
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
@@ -37,6 +40,16 @@ jobs:
             - name: Mark the workspace as safe
               # https://github.com/actions/checkout/issues/766
               run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
+            - name: Configure podman to allow the local registry
+              if: matrix.runtime == 'podman'
+              run: |
+                  # The registry service runs over plain HTTP on localhost:5000.
+                  # Podman rejects insecure registries by default, so we register
+                  # localhost:5000 as a trusted insecure source.
+                  sudo mkdir -p /etc/containers/registries.conf.d
+                  printf '[registries.insecure]\nregistries = ["localhost:5000"]\n' | \
+                      sudo tee /etc/containers/registries.conf.d/local-registry.conf
 
             - name: Install the static SDK
               run: |
@@ -57,9 +70,9 @@ jobs:
                       --repository localhost:5000/example \
                       --from ${{ matrix.from }}
 
-            - name: Run the example
+            - name: Run the example with ${{ matrix.runtime }}
               run: |
-                  docker run -d --platform linux/amd64 -p 8080:8080 localhost:5000/example
+                  ${{ matrix.runtime }} run -d --platform linux/amd64 -p 8080:8080 localhost:5000/example
 
             - name: Check that the service is running
               run: |


### PR DESCRIPTION
Closes #52

Adds `podman` as a second container runtime to the end-to-end test matrix, alongside the existing `docker` jobs.

### Changes

- Add `runtime: [docker, podman]` as a new matrix dimension in `endtoend_tests.yml`
- Add a "Configure podman to allow the local registry" step (runs only when `matrix.runtime == 'podman'`) that registers `localhost:5000` as an insecure registry in `/etc/containers/registries.conf.d/`. Podman rejects plain-HTTP registries by default, so this step is necessary for the local `registry:2` service used in CI.
- Replace the hardcoded `docker run` in the "Run the example" step with `${{ matrix.runtime }} run`, so the same step exercises both runtimes.

The step name also includes `${{ matrix.runtime }}` to make it easy to distinguish docker vs podman runs in the Actions UI.

I spotted this while looking through the open issue list after submitting previous PRs. Podman is pre-installed on ubuntu-latest, and since the test already pushes to a local registry and pulls from it at run time, switching the pull/run step to use podman should be a faithful compatibility check with no other changes needed.