### PR TITLE
containertool: Read defaults from containertool.json

### DIFF
--- a/Plugins/ContainerImageBuilder/main.swift
+++ b/Plugins/ContainerImageBuilder/main.swift
@@ -116,6 +116,8 @@ extension PluginError: CustomStringConvertible {
             + builtExecutables.map { $0.url.path }
             + extractor.remainingArguments
         let helperEnv = ProcessInfo.processInfo.environment.filter { $0.key.starts(with: "CONTAINERTOOL_") }
+        // Capture before entering the task group so the package directory is Sendable.
+        let packageDirectory = context.package.directoryURL
 
         let err = Pipe()
 
@@ -167,7 +169,14 @@ extension PluginError: CustomStringConvertible {
             }
 
             group.addTask {
-                try await run(command: helperURL, arguments: helperArgs, environment: helperEnv, errorPipe: err)
+                // Run from the package directory so project-local containertool.json is discovered.
+                try await run(
+                    command: helperURL,
+                    arguments: helperArgs,
+                    environment: helperEnv,
+                    currentDirectory: packageDirectory,
+                    errorPipe: err
+                )
             }
         }
     }

--- a/Plugins/ContainerImageBuilder/runner.swift
+++ b/Plugins/ContainerImageBuilder/runner.swift
@@ -22,6 +22,7 @@ public enum ExitCode: Error { case rawValue(Int32) }
 ///   - command: The URL for the executable.
 ///   - arguments: An array of arguments to supply to the executable.
 ///   - environment: A dictionary of environment variables to supply to the executable.
+///   - currentDirectory: The directory in which to run the executable.
 ///   - outputPipe: A Pipe to which to send anything the executable writes to standard output.
 ///   - errorPipe: A Pipe to which to send anything the executable writes to standard error.
 /// - Throws: `ExitCode` if the process terminates because of an uncaught signal.

--- a/Plugins/ContainerImageBuilder/runner.swift
+++ b/Plugins/ContainerImageBuilder/runner.swift
@@ -29,6 +29,7 @@ public func run(
     command: URL,
     arguments: [String],
     environment: [String: String]? = nil,
+    currentDirectory: URL? = nil,
     outputPipe: Pipe? = nil,
     errorPipe: Pipe? = nil
 ) async throws {
@@ -37,6 +38,7 @@ public func run(
     task.executableURL = command
     task.arguments = arguments
     task.environment = environment
+    if let currentDirectory { task.currentDirectoryURL = currentDirectory }
     if let outputPipe { task.standardOutput = outputPipe }
     if let errorPipe { task.standardError = errorPipe }
 

--- a/Sources/containertool/ConfigurationFile.swift
+++ b/Sources/containertool/ConfigurationFile.swift
@@ -1,0 +1,146 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftContainerPlugin open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftContainerPlugin project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftContainerPlugin project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Defaults loaded from a project-local `containertool.json` configuration file.
+///
+/// Values from this file are applied after built-in defaults and before environment
+/// variables and command-line flags.  Command-line flags take precedence over
+/// environment variables, which take precedence over this file.
+struct ContainerToolConfiguration: Equatable, Sendable {
+    /// Filename searched for in the project directory.
+    static let filename = "containertool.json"
+
+    var defaultRegistry: String?
+    var repository: String?
+    var tag: String?
+    var from: String?
+    var architecture: String?
+    var os: String?
+    var defaultUsername: String?
+    var defaultPassword: String?
+
+    /// An empty configuration with no values set.
+    static let empty = ContainerToolConfiguration()
+
+    /// Loads configuration by searching for ``filename`` starting at `directory`
+    /// and walking up parent directories until the file is found or the filesystem
+    /// root is reached.
+    ///
+    /// - Parameter directory: Directory at which to begin the search.
+    /// - Returns: The decoded configuration and the URL of the file that was loaded,
+    ///   or `nil` if no configuration file was found.
+    /// - Throws: If a configuration file exists but cannot be read or decoded.
+    static func load(
+        startingAt directory: URL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    ) throws -> (configuration: ContainerToolConfiguration, url: URL)? {
+        guard let url = findConfigurationFile(startingAt: directory) else {
+            return nil
+        }
+        return (try load(from: url), url)
+    }
+
+    /// Loads and decodes a configuration file at `url`.
+    ///
+    /// - Parameter url: Path to a `containertool.json` file.
+    /// - Returns: The decoded configuration.
+    /// - Throws: If the file cannot be read or is not valid JSON for this schema.
+    static func load(from url: URL) throws -> ContainerToolConfiguration {
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            throw ConfigurationFileError.unreadable(path: url.path, underlying: error)
+        }
+
+        let decoded: FileContents
+        do {
+            decoded = try JSONDecoder().decode(FileContents.self, from: data)
+        } catch {
+            throw ConfigurationFileError.invalid(path: url.path, underlying: error)
+        }
+
+        return ContainerToolConfiguration(
+            defaultRegistry: decoded.defaultRegistry.nonEmpty,
+            repository: decoded.repository.nonEmpty,
+            tag: decoded.tag.nonEmpty,
+            from: decoded.from.nonEmpty,
+            architecture: decoded.architecture.nonEmpty,
+            os: decoded.os.nonEmpty,
+            defaultUsername: decoded.defaultUsername.nonEmpty,
+            defaultPassword: decoded.defaultPassword.nonEmpty
+        )
+    }
+
+    /// Searches for ``filename`` starting at `directory` and walking up toward the root.
+    ///
+    /// - Parameter directory: Directory at which to begin the search.
+    /// - Returns: The URL of the first matching file, or `nil` if none is found.
+    static func findConfigurationFile(startingAt directory: URL) -> URL? {
+        var current = directory.standardizedFileURL
+        let fm = FileManager.default
+
+        while true {
+            let candidate = current.appendingPathComponent(filename)
+            if fm.isReadableFile(atPath: candidate.path) {
+                return candidate
+            }
+
+            let parent = current.deletingLastPathComponent()
+            if parent.path == current.path {
+                return nil
+            }
+            current = parent
+        }
+    }
+}
+
+enum ConfigurationFileError: Error, CustomStringConvertible, Equatable {
+    case unreadable(path: String, underlying: Error)
+    case invalid(path: String, underlying: Error)
+
+    var description: String {
+        switch self {
+        case .unreadable(let path, let underlying):
+            return "Unable to read configuration file \(path): \(underlying)"
+        case .invalid(let path, let underlying):
+            return "Invalid configuration file \(path): \(underlying)"
+        }
+    }
+
+    static func == (lhs: ConfigurationFileError, rhs: ConfigurationFileError) -> Bool {
+        lhs.description == rhs.description
+    }
+}
+
+extension ContainerToolConfiguration {
+    private struct FileContents: Decodable {
+        var defaultRegistry: String?
+        var repository: String?
+        var tag: String?
+        var from: String?
+        var architecture: String?
+        var os: String?
+        var defaultUsername: String?
+        var defaultPassword: String?
+    }
+}
+
+extension Optional where Wrapped == String {
+    fileprivate var nonEmpty: String? {
+        guard let self, !self.isEmpty else { return nil }
+        return self
+    }
+}

--- a/Sources/containertool/containertool.swift
+++ b/Sources/containertool/containertool.swift
@@ -149,20 +149,49 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
 
     func run() async throws {
         // MARK: Apply defaults for unspecified configuration flags
+        // Precedence: command-line flags > environment variables > containertool.json > built-in defaults
 
         let env = ProcessInfo.processInfo.environment
+        let loadedConfig = try ContainerToolConfiguration.load()
+        let config = loadedConfig?.configuration ?? .empty
+        if verbose, let configURL = loadedConfig?.url {
+            log("Loaded configuration from \(configURL.path)")
+        }
 
-        let defaultRegistry = repositoryOptions.defaultRegistry ?? env["CONTAINERTOOL_DEFAULT_REGISTRY"] ?? "docker.io"
-        guard let repository = repositoryOptions.repository ?? env["CONTAINERTOOL_REPOSITORY"] else {
+        let defaultRegistry =
+            repositoryOptions.defaultRegistry
+            ?? env["CONTAINERTOOL_DEFAULT_REGISTRY"]
+            ?? config.defaultRegistry
+            ?? "docker.io"
+        guard
+            let repository = repositoryOptions.repository
+                ?? env["CONTAINERTOOL_REPOSITORY"]
+                ?? config.repository
+        else {
             throw ValidationError(
-                "Please specify the destination repository using --repository or CONTAINERTOOL_REPOSITORY"
+                "Please specify the destination repository using --repository, CONTAINERTOOL_REPOSITORY, or containertool.json"
             )
         }
 
-        let username = authenticationOptions.defaultUsername ?? env["CONTAINERTOOL_DEFAULT_USERNAME"]
-        let password = authenticationOptions.defaultPassword ?? env["CONTAINERTOOL_DEFAULT_PASSWORD"]
-        let from = repositoryOptions.from ?? env["CONTAINERTOOL_BASE_IMAGE"] ?? "swift:slim"
-        let os = imageConfigurationOptions.os ?? env["CONTAINERTOOL_OS"] ?? "linux"
+        let username =
+            authenticationOptions.defaultUsername
+            ?? env["CONTAINERTOOL_DEFAULT_USERNAME"]
+            ?? config.defaultUsername
+        let password =
+            authenticationOptions.defaultPassword
+            ?? env["CONTAINERTOOL_DEFAULT_PASSWORD"]
+            ?? config.defaultPassword
+        let from =
+            repositoryOptions.from
+            ?? env["CONTAINERTOOL_BASE_IMAGE"]
+            ?? config.from
+            ?? "swift:slim"
+        let os =
+            imageConfigurationOptions.os
+            ?? env["CONTAINERTOOL_OS"]
+            ?? config.os
+            ?? "linux"
+        let tag = repositoryOptions.tag ?? config.tag
 
         // Try to detect the architecture of the application executable so a suitable base image can be selected.
         // This reduces the risk of accidentally creating an image which stacks an aarch64 executable on top of an x86_64 base image.
@@ -172,6 +201,7 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
         let architecture =
             imageConfigurationOptions.architecture
             ?? env["CONTAINERTOOL_ARCHITECTURE"]
+            ?? config.architecture
             ?? elfheader?.ISA.containerArchitecture
             ?? "amd64"
         if verbose { log("Base image architecture: \(architecture)") }
@@ -235,7 +265,7 @@ enum AllowHTTP: String, ExpressibleByArgument, CaseIterable { case source, desti
             cmd: imageConfigurationOptions.cmd,
             additionalEnv: imageConfigurationOptions.env,
             resources: imageBuildOptions.resources,
-            tag: repositoryOptions.tag,
+            tag: tag,
             verbose: verbose,
             executableURL: executableURL
         )

--- a/Sources/swift-container-plugin/Documentation.docc/build-container-image.md
+++ b/Sources/swift-container-plugin/Documentation.docc/build-container-image.md
@@ -28,7 +28,7 @@ Wrap a binary in a container image and publish it.
   Destination image repository.
 
   If the repository path does not begin with a registry hostname, the default registry will be prepended to the path.
-  The destination repository must be specified, either by setting the `--repository` option or the `CONTAINERTOOL_REPOSITORY` environment variable.
+  The destination repository must be specified, either by setting the `--repository` option, the `CONTAINERTOOL_REPOSITORY` environment variable, or the `repository` field in `containertool.json`.
 
 - term  `--tag <tag>`:
   The tag to apply to the destination image.
@@ -91,6 +91,29 @@ Wrap a binary in a container image and publish it.
 - term  `-h, --help`:
   Show help information.
 
+
+### Configuration file
+
+`containertool` looks for a `containertool.json` file in the current working directory, then in parent directories.
+Values from this file supply defaults for options that are not set on the command line or by environment variables.
+
+Precedence is: command-line flags, then environment variables, then `containertool.json`, then built-in defaults.
+
+```json
+{
+  "defaultRegistry": "docker.io",
+  "repository": "registry.example.com/myservice",
+  "tag": "1.0.0",
+  "from": "swift:slim",
+  "architecture": "amd64",
+  "os": "linux",
+  "defaultUsername": "example",
+  "defaultPassword": "secret"
+}
+```
+
+All fields are optional.  Prefer `.netrc` or environment variables for credentials when possible.
+
 ### Environment
 
 - term `CONTAINERTOOL_DEFAULT_REGISTRY`:
@@ -101,7 +124,7 @@ Wrap a binary in a container image and publish it.
   The destination image repository.
 
   If the path does not begin with a registry hostname, the default registry will be prepended to the path.
-  The destination repository must be specified, either by setting the `--repository` option or the `CONTAINERTOOL_REPOSITORY` environment variable.
+  The destination repository must be specified, either by setting the `--repository` option, the `CONTAINERTOOL_REPOSITORY` environment variable, or the `repository` field in `containertool.json`.
 
 - term `CONTAINERTOOL_BASE_IMAGE`:
   Base image on which to layer the application.

--- a/Sources/swift-container-plugin/Documentation.docc/build.md
+++ b/Sources/swift-container-plugin/Documentation.docc/build.md
@@ -14,6 +14,7 @@ The plugin exposes the command `build-container-image` which you invoke to build
 * The `--swift-sdk` argument specifies the Swift SDK with which to build the executable.   In this case we are using the Static Linux SDK, [installed earlier](<doc:requirements>), to build an statically-linked x86_64 Linux executable.
 * The `--from` argument specifies the base image on which our service will run.   `swift:slim` is the default, but you can choose your own base image or use `scratch` if your service does not require a base image at all.
 * The `--repository` argument specifies the repository to which the plugin will publish the finished image.
+* Defaults for these options can also be set in a project-local `containertool.json` file; see <doc:build-container-image>.
 
 > Note: on macOS, the plugin needs permission to connect to the network to publish the image to the registry.
 >

--- a/Tests/containertoolTests/ConfigurationFileTests.swift
+++ b/Tests/containertoolTests/ConfigurationFileTests.swift
@@ -1,0 +1,111 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftContainerPlugin open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftContainerPlugin project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftContainerPlugin project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import containertool
+
+@Suite struct ConfigurationFileTests {
+    @Test func loadFullConfiguration() throws {
+        try withTemporaryDirectory { directory in
+            let url = directory.appendingPathComponent(ContainerToolConfiguration.filename)
+            try """
+                {
+                  "defaultRegistry": "ghcr.io",
+                  "repository": "example/service",
+                  "tag": "1.2.3",
+                  "from": "swift:slim",
+                  "architecture": "arm64",
+                  "os": "linux",
+                  "defaultUsername": "user",
+                  "defaultPassword": "secret"
+                }
+                """.write(to: url, atomically: true, encoding: .utf8)
+
+            let config = try ContainerToolConfiguration.load(from: url)
+            #expect(
+                config == ContainerToolConfiguration(
+                    defaultRegistry: "ghcr.io",
+                    repository: "example/service",
+                    tag: "1.2.3",
+                    from: "swift:slim",
+                    architecture: "arm64",
+                    os: "linux",
+                    defaultUsername: "user",
+                    defaultPassword: "secret"
+                )
+            )
+        }
+    }
+
+    @Test func loadPartialConfigurationIgnoresEmptyStrings() throws {
+        try withTemporaryDirectory { directory in
+            let url = directory.appendingPathComponent(ContainerToolConfiguration.filename)
+            try """
+                {
+                  "repository": "example/service",
+                  "from": "",
+                  "tag": null
+                }
+                """.write(to: url, atomically: true, encoding: .utf8)
+
+            let config = try ContainerToolConfiguration.load(from: url)
+            #expect(config.repository == "example/service")
+            #expect(config.from == nil)
+            #expect(config.tag == nil)
+            #expect(config.defaultRegistry == nil)
+        }
+    }
+
+    @Test func loadReturnsNilWhenFileIsMissing() throws {
+        try withTemporaryDirectory { directory in
+            let loaded = try ContainerToolConfiguration.load(startingAt: directory)
+            #expect(loaded == nil)
+        }
+    }
+
+    @Test func findConfigurationFileWalksParentDirectories() throws {
+        try withTemporaryDirectory { directory in
+            let configURL = directory.appendingPathComponent(ContainerToolConfiguration.filename)
+            try #"{"repository":"example/from-parent"}"#.write(to: configURL, atomically: true, encoding: .utf8)
+
+            let nested = directory.appendingPathComponent("Sources").appendingPathComponent("App")
+            try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+
+            let loaded = try #require(try ContainerToolConfiguration.load(startingAt: nested))
+            #expect(loaded.url.path == configURL.path)
+            #expect(loaded.configuration.repository == "example/from-parent")
+        }
+    }
+
+    @Test func loadThrowsForInvalidJSON() throws {
+        try withTemporaryDirectory { directory in
+            let url = directory.appendingPathComponent(ContainerToolConfiguration.filename)
+            try "{ not valid json".write(to: url, atomically: true, encoding: .utf8)
+
+            #expect(throws: ConfigurationFileError.self) {
+                _ = try ContainerToolConfiguration.load(from: url)
+            }
+        }
+    }
+}
+
+private func withTemporaryDirectory(_ body: (URL) throws -> Void) throws {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("containertool-config-tests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    try body(directory)
+}


### PR DESCRIPTION
## Summary
- Add project-local `containertool.json` support so `containertool` can load defaults for repository, registry, base image, tag, architecture, OS, and credentials.
- Apply precedence: CLI flags > environment variables > `containertool.json` > built-in defaults.
- Discover the config file from the working directory (walking parents) and run the plugin helper from the package directory so the file is found.
- Document the configuration file and add unit tests for loading/parsing.

Fixes #87

## Test plan
- [x] `swift build --product containertool` succeeds
- [ ] `swift test --filter ConfigurationFileTests`
- [ ] Create `containertool.json` with `"repository"` and confirm `containertool` uses it without `--repository`
- [ ] Set `CONTAINERTOOL_REPOSITORY` and confirm it overrides the config file
- [ ] Pass `--repository` and confirm it overrides both env and config